### PR TITLE
Give granular controls on Laravel automations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ You must have these installed on your system.
 1. All templates are stored in the `/templates` folder
 1. I have a Git "Pre-Commit" hook that runs `build.sh`
 1. `build.sh` copies the templates and applies the templates with [yasha](https://github.com/kblomqvist/yasha)
-1. All generated files are then stored in the `/php` folder
+1. All generated files are then stored in the `/generated-dockerfiles` folder
 1. Github Actions will read the generated files and build images from the generated files
 
 # Running things locally

--- a/README.md
+++ b/README.md
@@ -114,17 +114,19 @@ We have a ton of helpful scripts and security settings configured for managing L
 ### Automated tasks executed on every container start up
 We automatically look at your Laravel `.env` file and determine if theses tasks should be run. 
 
-If your `APP_ENV != local`(any environment other than local development), we will automatically run these repetitive tasks for you every time the container spins up:
+If your `APP_ENV != local`(any environment other than local development), we :
 
 **Database Migrations:**
 ```sh
 php /var/www/html/artisan migrate --force
 ```
+You must enable this manually by setting `AUTORUN_LARAVEL_MIGRATION=true` on your container.
+
 **Storage Linking:**
 ```sh
 php /var/www/html/artisan storage:link
 ```
-
+This will run automatically for environments that are not `local`.
 
 ### Running a Laravel Task Scheduler
 We need to run the [schedule:work](https://laravel.com/docs/8.x/scheduling#running-the-scheduler-locally) command from Laravel. Although the docs say "Running the scheduler locally", this is what we want in production. It will run the scheduler in the foreground and execute it every minute. You can configure your Laravel app for the exact time that a command should run through a [scheduled task](https://laravel.com/docs/8.x/scheduling#scheduling-artisan-commands).

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ PHP\_PM\_START\_SERVERS|The number of child processes created on startup. Used o
 PHP\_POOL\_NAME|Set the name of your PHP-FPM pool (helpful when running multiple sites on a single server).|fpm,<br />fpm-nginx,<br />fpm-apache|"www"
 PHP\_POST\_MAX\_SIZE|Sets max size of post data allowed. (<a href="https://www.php.net/manual/en/ini.core.php#ini.post-max-size">Official docs</a>)|fpm,<br />fpm-nginx,<br />fpm-apache|"100M"
 PHP\_UPLOAD\_MAX\_FILE\_SIZE|The maximum size of an uploaded file. (<a href="https://www.php.net/manual/en/ini.core.php#ini.upload-max-filesize">Official docs</a>)|fpm,<br />fpm-nginx,<br />fpm-apache|"100M"
-AUTORUN\_LARAVEL\_MIGRATION|For non-local Laravel installs only: Automatically run "php artisan storage:link" on container start|fpm,<br />fpm-nginx,<br />fpm-apache|"true"
+AUTORUN\_LARAVEL\_STORAGE\_LINK|For non-local Laravel installs only: Automatically run "php artisan storage:link" on container start|fpm,<br />fpm-nginx,<br />fpm-apache|"true"
 AUTORUN\_LARAVEL\_MIGRATION|For non-local Laravel installs only: Automatically run "php artisan migrate --force" on container start|fpm,<br />fpm-nginx,<br />fpm-apache|"false"
 MSMTP\_RELAY\_SERVER\_HOSTNAME|Server that should relay emails for MSMTP. (<a href="https://marlam.de/msmtp/msmtp.html">Official docs</a>)|fpm-nginx,<br />fpm-apache|"mailhog"<br /><br />🚨 IMPORTANT: Change this value if you want emails to work. (we set it to <a href="https://github.com/mailhog/MailHog">Mailhog</a> so our staging sites do not send emails out)
 MSMTP\_RELAY\_SERVER\_PORT|Port the SMTP server is listening on. (<a href="https://marlam.de/msmtp/msmtp.html">Official docs</a>)|fpm-nginx,<br />fpm-apache|"1025" (default port for Mailhog)

--- a/README.md
+++ b/README.md
@@ -241,7 +241,8 @@ PHP\_PM\_START\_SERVERS|The number of child processes created on startup. Used o
 PHP\_POOL\_NAME|Set the name of your PHP-FPM pool (helpful when running multiple sites on a single server).|fpm,<br />fpm-nginx,<br />fpm-apache|"www"
 PHP\_POST\_MAX\_SIZE|Sets max size of post data allowed. (<a href="https://www.php.net/manual/en/ini.core.php#ini.post-max-size">Official docs</a>)|fpm,<br />fpm-nginx,<br />fpm-apache|"100M"
 PHP\_UPLOAD\_MAX\_FILE\_SIZE|The maximum size of an uploaded file. (<a href="https://www.php.net/manual/en/ini.core.php#ini.upload-max-filesize">Official docs</a>)|fpm,<br />fpm-nginx,<br />fpm-apache|"100M"
-RUN\_LARAVEL\_AUTOMATIONS|Automatically run the Laravel Automations (for non-local Laravel installs only)|fpm,<br />fpm-nginx,<br />fpm-apache|"true"
+AUTORUN\_LARAVEL\_MIGRATION|For non-local Laravel installs only: Automatically run "php artisan storage:link" on container start|fpm,<br />fpm-nginx,<br />fpm-apache|"true"
+AUTORUN\_LARAVEL\_MIGRATION|For non-local Laravel installs only: Automatically run "php artisan migrate --force" on container start|fpm,<br />fpm-nginx,<br />fpm-apache|"false"
 MSMTP\_RELAY\_SERVER\_HOSTNAME|Server that should relay emails for MSMTP. (<a href="https://marlam.de/msmtp/msmtp.html">Official docs</a>)|fpm-nginx,<br />fpm-apache|"mailhog"<br /><br />🚨 IMPORTANT: Change this value if you want emails to work. (we set it to <a href="https://github.com/mailhog/MailHog">Mailhog</a> so our staging sites do not send emails out)
 MSMTP\_RELAY\_SERVER\_PORT|Port the SMTP server is listening on. (<a href="https://marlam.de/msmtp/msmtp.html">Official docs</a>)|fpm-nginx,<br />fpm-apache|"1025" (default port for Mailhog)
 DEBUG\_OUTPUT|Set this variable to `true` if you want to put PHP and your web server in debug mode.|fpm-nginx,<br />fpm-apache|(undefined, false)

--- a/generated-dockerfiles/7.4/fpm/etc/cont-init.d/50-laravel-automations
+++ b/generated-dockerfiles/7.4/fpm/etc/cont-init.d/50-laravel-automations
@@ -12,6 +12,7 @@ if [ -f $WEBUSER_HOME/artisan ]; then
 
     # If Laravel is not running in development or CI, then automate some production tasks
     if [ "$APP_ENV_SETTING" != "local" ] && [ ! -z $APP_ENV_SETTING ] && [ ${CI_ENV:="false"} != "true" ]; then
+            echo "🏃‍♂️ Checking for Laravel automations..."
 
         ############################################################################
         # Automated database migrations

--- a/generated-dockerfiles/7.4/fpm/etc/cont-init.d/50-laravel-automations
+++ b/generated-dockerfiles/7.4/fpm/etc/cont-init.d/50-laravel-automations
@@ -13,21 +13,10 @@ if [ -f $WEBUSER_HOME/artisan ]; then
     # If Laravel is not running in development or CI, then automate some production tasks
     if [ "$APP_ENV_SETTING" != "local" ] && [ ! -z $APP_ENV_SETTING ] && [ ${CI_ENV:="false"} != "true" ]; then
 
-        # ############################################################################
-        # # Cache management - commented out for now because of a bug with Laravel caching & API Rate limiting
-        # ############################################################################
-        # echo "♻️ Refreshing cache..."
-        # # Clear cache
-        # su - webuser -c "php $WEBUSER_HOME/artisan cache:clear"
-
-        # # Set cache
-        # su - webuser -c "php $WEBUSER_HOME/artisan route:cache"
-        # su - webuser -c "php $WEBUSER_HOME/artisan view:cache"
-
         ############################################################################
         # Automated database migrations
         ############################################################################
-        if grep -q DB_DATABASE $WEBUSER_HOME/.env; then
+        if [ grep -q DB_DATABASE $WEBUSER_HOME/.env ] && [ ${AUTORUN_LARAVEL_MIGRATION:="false"} == "true" ]; then
             echo "🚀 Running migrations..."
             su - webuser -c "php $WEBUSER_HOME/artisan migrate --force"
         fi
@@ -35,9 +24,25 @@ if [ -f $WEBUSER_HOME/artisan ]; then
         ############################################################################
         # Automated storage linking
         ############################################################################
-        echo "🔐 Linking the storage..."
-        su - webuser -c "php $WEBUSER_HOME/artisan storage:link"
+        if [ ${AUTORUN_LARAVEL_STORAGE_LINK:="true"} == "true" ]; then
+            echo "🔐 Linking the storage..."
+            su - webuser -c "php $WEBUSER_HOME/artisan storage:link"
+        fi
+
+        ############################################################################
+        # Cache management - commented out for now because of a bug with Laravel caching & API Rate limiting
+        ############################################################################
+        # if [ ${AUTORUN_LARAVEL_REFRESH_CACHE:="true"} == "true" ]; then
+        #     echo "♻️ Refreshing cache..."
+        #     # Clear cache
+        #     su - webuser -c "php $WEBUSER_HOME/artisan cache:clear"
+
+        #     # Set cache
+        #     su - webuser -c "php $WEBUSER_HOME/artisan route:cache"
+        #     su - webuser -c "php $WEBUSER_HOME/artisan view:cache"
+        # fi
+
     else
-        echo "👉 Skipping Laravel production commands because the env is set to 'local', running in CI, or explicitly disabled..."
+        echo "👉 Skipping Laravel automations because the env is set to 'local' or running in CI..."
     fi
 fi

--- a/generated-dockerfiles/7.4/fpm/etc/cont-init.d/50-laravel-automations
+++ b/generated-dockerfiles/7.4/fpm/etc/cont-init.d/50-laravel-automations
@@ -16,7 +16,7 @@ if [ -f $WEBUSER_HOME/artisan ]; then
         ############################################################################
         # Automated database migrations
         ############################################################################
-        if [ grep -q DB_DATABASE $WEBUSER_HOME/.env ] && [ ${AUTORUN_LARAVEL_MIGRATION:="false"} == "true" ]; then
+        if [ "grep -q DB_DATABASE $WEBUSER_HOME/.env" ] && [ ${AUTORUN_LARAVEL_MIGRATION:="false"} == "true" ]; then
             echo "🚀 Running migrations..."
             su - webuser -c "php $WEBUSER_HOME/artisan migrate --force"
         fi

--- a/generated-dockerfiles/7.4/fpm/etc/cont-init.d/50-laravel-automations
+++ b/generated-dockerfiles/7.4/fpm/etc/cont-init.d/50-laravel-automations
@@ -11,7 +11,7 @@ if [ -f $WEBUSER_HOME/artisan ]; then
     APP_ENV_SETTING=$(cat $WEBUSER_HOME/.env | grep APP_ENV | cut -f2 -d"=")
 
     # If Laravel is not running in development or CI, then automate some production tasks
-    if [ "$APP_ENV_SETTING" != "local" ] && [ ! -z $APP_ENV_SETTING ] && [ ${CI_ENV:="false"} != "true" ] && [ ${RUN_LARAVEL_AUTOMATIONS:="true"} == "true" ]; then
+    if [ "$APP_ENV_SETTING" != "local" ] && [ ! -z $APP_ENV_SETTING ] && [ ${CI_ENV:="false"} != "true" ]; then
 
         # ############################################################################
         # # Cache management - commented out for now because of a bug with Laravel caching & API Rate limiting

--- a/generated-dockerfiles/8.0/fpm/etc/cont-init.d/50-laravel-automations
+++ b/generated-dockerfiles/8.0/fpm/etc/cont-init.d/50-laravel-automations
@@ -12,6 +12,7 @@ if [ -f $WEBUSER_HOME/artisan ]; then
 
     # If Laravel is not running in development or CI, then automate some production tasks
     if [ "$APP_ENV_SETTING" != "local" ] && [ ! -z $APP_ENV_SETTING ] && [ ${CI_ENV:="false"} != "true" ]; then
+            echo "🏃‍♂️ Checking for Laravel automations..."
 
         ############################################################################
         # Automated database migrations

--- a/generated-dockerfiles/8.0/fpm/etc/cont-init.d/50-laravel-automations
+++ b/generated-dockerfiles/8.0/fpm/etc/cont-init.d/50-laravel-automations
@@ -13,21 +13,10 @@ if [ -f $WEBUSER_HOME/artisan ]; then
     # If Laravel is not running in development or CI, then automate some production tasks
     if [ "$APP_ENV_SETTING" != "local" ] && [ ! -z $APP_ENV_SETTING ] && [ ${CI_ENV:="false"} != "true" ]; then
 
-        # ############################################################################
-        # # Cache management - commented out for now because of a bug with Laravel caching & API Rate limiting
-        # ############################################################################
-        # echo "♻️ Refreshing cache..."
-        # # Clear cache
-        # su - webuser -c "php $WEBUSER_HOME/artisan cache:clear"
-
-        # # Set cache
-        # su - webuser -c "php $WEBUSER_HOME/artisan route:cache"
-        # su - webuser -c "php $WEBUSER_HOME/artisan view:cache"
-
         ############################################################################
         # Automated database migrations
         ############################################################################
-        if grep -q DB_DATABASE $WEBUSER_HOME/.env; then
+        if [ grep -q DB_DATABASE $WEBUSER_HOME/.env ] && [ ${AUTORUN_LARAVEL_MIGRATION:="false"} == "true" ]; then
             echo "🚀 Running migrations..."
             su - webuser -c "php $WEBUSER_HOME/artisan migrate --force"
         fi
@@ -35,9 +24,25 @@ if [ -f $WEBUSER_HOME/artisan ]; then
         ############################################################################
         # Automated storage linking
         ############################################################################
-        echo "🔐 Linking the storage..."
-        su - webuser -c "php $WEBUSER_HOME/artisan storage:link"
+        if [ ${AUTORUN_LARAVEL_STORAGE_LINK:="true"} == "true" ]; then
+            echo "🔐 Linking the storage..."
+            su - webuser -c "php $WEBUSER_HOME/artisan storage:link"
+        fi
+
+        ############################################################################
+        # Cache management - commented out for now because of a bug with Laravel caching & API Rate limiting
+        ############################################################################
+        # if [ ${AUTORUN_LARAVEL_REFRESH_CACHE:="true"} == "true" ]; then
+        #     echo "♻️ Refreshing cache..."
+        #     # Clear cache
+        #     su - webuser -c "php $WEBUSER_HOME/artisan cache:clear"
+
+        #     # Set cache
+        #     su - webuser -c "php $WEBUSER_HOME/artisan route:cache"
+        #     su - webuser -c "php $WEBUSER_HOME/artisan view:cache"
+        # fi
+
     else
-        echo "👉 Skipping Laravel production commands because the env is set to 'local', running in CI, or explicitly disabled..."
+        echo "👉 Skipping Laravel automations because the env is set to 'local' or running in CI..."
     fi
 fi

--- a/generated-dockerfiles/8.0/fpm/etc/cont-init.d/50-laravel-automations
+++ b/generated-dockerfiles/8.0/fpm/etc/cont-init.d/50-laravel-automations
@@ -16,7 +16,7 @@ if [ -f $WEBUSER_HOME/artisan ]; then
         ############################################################################
         # Automated database migrations
         ############################################################################
-        if [ grep -q DB_DATABASE $WEBUSER_HOME/.env ] && [ ${AUTORUN_LARAVEL_MIGRATION:="false"} == "true" ]; then
+        if [ "grep -q DB_DATABASE $WEBUSER_HOME/.env" ] && [ ${AUTORUN_LARAVEL_MIGRATION:="false"} == "true" ]; then
             echo "🚀 Running migrations..."
             su - webuser -c "php $WEBUSER_HOME/artisan migrate --force"
         fi

--- a/generated-dockerfiles/8.0/fpm/etc/cont-init.d/50-laravel-automations
+++ b/generated-dockerfiles/8.0/fpm/etc/cont-init.d/50-laravel-automations
@@ -11,7 +11,7 @@ if [ -f $WEBUSER_HOME/artisan ]; then
     APP_ENV_SETTING=$(cat $WEBUSER_HOME/.env | grep APP_ENV | cut -f2 -d"=")
 
     # If Laravel is not running in development or CI, then automate some production tasks
-    if [ "$APP_ENV_SETTING" != "local" ] && [ ! -z $APP_ENV_SETTING ] && [ ${CI_ENV:="false"} != "true" ] && [ ${RUN_LARAVEL_AUTOMATIONS:="true"} == "true" ]; then
+    if [ "$APP_ENV_SETTING" != "local" ] && [ ! -z $APP_ENV_SETTING ] && [ ${CI_ENV:="false"} != "true" ]; then
 
         # ############################################################################
         # # Cache management - commented out for now because of a bug with Laravel caching & API Rate limiting

--- a/generated-dockerfiles/8.1/fpm/etc/cont-init.d/50-laravel-automations
+++ b/generated-dockerfiles/8.1/fpm/etc/cont-init.d/50-laravel-automations
@@ -12,6 +12,7 @@ if [ -f $WEBUSER_HOME/artisan ]; then
 
     # If Laravel is not running in development or CI, then automate some production tasks
     if [ "$APP_ENV_SETTING" != "local" ] && [ ! -z $APP_ENV_SETTING ] && [ ${CI_ENV:="false"} != "true" ]; then
+            echo "🏃‍♂️ Checking for Laravel automations..."
 
         ############################################################################
         # Automated database migrations

--- a/generated-dockerfiles/8.1/fpm/etc/cont-init.d/50-laravel-automations
+++ b/generated-dockerfiles/8.1/fpm/etc/cont-init.d/50-laravel-automations
@@ -13,21 +13,10 @@ if [ -f $WEBUSER_HOME/artisan ]; then
     # If Laravel is not running in development or CI, then automate some production tasks
     if [ "$APP_ENV_SETTING" != "local" ] && [ ! -z $APP_ENV_SETTING ] && [ ${CI_ENV:="false"} != "true" ]; then
 
-        # ############################################################################
-        # # Cache management - commented out for now because of a bug with Laravel caching & API Rate limiting
-        # ############################################################################
-        # echo "♻️ Refreshing cache..."
-        # # Clear cache
-        # su - webuser -c "php $WEBUSER_HOME/artisan cache:clear"
-
-        # # Set cache
-        # su - webuser -c "php $WEBUSER_HOME/artisan route:cache"
-        # su - webuser -c "php $WEBUSER_HOME/artisan view:cache"
-
         ############################################################################
         # Automated database migrations
         ############################################################################
-        if grep -q DB_DATABASE $WEBUSER_HOME/.env; then
+        if [ grep -q DB_DATABASE $WEBUSER_HOME/.env ] && [ ${AUTORUN_LARAVEL_MIGRATION:="false"} == "true" ]; then
             echo "🚀 Running migrations..."
             su - webuser -c "php $WEBUSER_HOME/artisan migrate --force"
         fi
@@ -35,9 +24,25 @@ if [ -f $WEBUSER_HOME/artisan ]; then
         ############################################################################
         # Automated storage linking
         ############################################################################
-        echo "🔐 Linking the storage..."
-        su - webuser -c "php $WEBUSER_HOME/artisan storage:link"
+        if [ ${AUTORUN_LARAVEL_STORAGE_LINK:="true"} == "true" ]; then
+            echo "🔐 Linking the storage..."
+            su - webuser -c "php $WEBUSER_HOME/artisan storage:link"
+        fi
+
+        ############################################################################
+        # Cache management - commented out for now because of a bug with Laravel caching & API Rate limiting
+        ############################################################################
+        # if [ ${AUTORUN_LARAVEL_REFRESH_CACHE:="true"} == "true" ]; then
+        #     echo "♻️ Refreshing cache..."
+        #     # Clear cache
+        #     su - webuser -c "php $WEBUSER_HOME/artisan cache:clear"
+
+        #     # Set cache
+        #     su - webuser -c "php $WEBUSER_HOME/artisan route:cache"
+        #     su - webuser -c "php $WEBUSER_HOME/artisan view:cache"
+        # fi
+
     else
-        echo "👉 Skipping Laravel production commands because the env is set to 'local', running in CI, or explicitly disabled..."
+        echo "👉 Skipping Laravel automations because the env is set to 'local' or running in CI..."
     fi
 fi

--- a/generated-dockerfiles/8.1/fpm/etc/cont-init.d/50-laravel-automations
+++ b/generated-dockerfiles/8.1/fpm/etc/cont-init.d/50-laravel-automations
@@ -16,7 +16,7 @@ if [ -f $WEBUSER_HOME/artisan ]; then
         ############################################################################
         # Automated database migrations
         ############################################################################
-        if [ grep -q DB_DATABASE $WEBUSER_HOME/.env ] && [ ${AUTORUN_LARAVEL_MIGRATION:="false"} == "true" ]; then
+        if [ "grep -q DB_DATABASE $WEBUSER_HOME/.env" ] && [ ${AUTORUN_LARAVEL_MIGRATION:="false"} == "true" ]; then
             echo "🚀 Running migrations..."
             su - webuser -c "php $WEBUSER_HOME/artisan migrate --force"
         fi

--- a/generated-dockerfiles/8.1/fpm/etc/cont-init.d/50-laravel-automations
+++ b/generated-dockerfiles/8.1/fpm/etc/cont-init.d/50-laravel-automations
@@ -11,7 +11,7 @@ if [ -f $WEBUSER_HOME/artisan ]; then
     APP_ENV_SETTING=$(cat $WEBUSER_HOME/.env | grep APP_ENV | cut -f2 -d"=")
 
     # If Laravel is not running in development or CI, then automate some production tasks
-    if [ "$APP_ENV_SETTING" != "local" ] && [ ! -z $APP_ENV_SETTING ] && [ ${CI_ENV:="false"} != "true" ] && [ ${RUN_LARAVEL_AUTOMATIONS:="true"} == "true" ]; then
+    if [ "$APP_ENV_SETTING" != "local" ] && [ ! -z $APP_ENV_SETTING ] && [ ${CI_ENV:="false"} != "true" ]; then
 
         # ############################################################################
         # # Cache management - commented out for now because of a bug with Laravel caching & API Rate limiting

--- a/templates/fpm/etc/cont-init.d/50-laravel-automations
+++ b/templates/fpm/etc/cont-init.d/50-laravel-automations
@@ -12,6 +12,7 @@ if [ -f $WEBUSER_HOME/artisan ]; then
 
     # If Laravel is not running in development or CI, then automate some production tasks
     if [ "$APP_ENV_SETTING" != "local" ] && [ ! -z $APP_ENV_SETTING ] && [ ${CI_ENV:="false"} != "true" ]; then
+            echo "🏃‍♂️ Checking for Laravel automations..."
 
         ############################################################################
         # Automated database migrations

--- a/templates/fpm/etc/cont-init.d/50-laravel-automations
+++ b/templates/fpm/etc/cont-init.d/50-laravel-automations
@@ -16,7 +16,7 @@ if [ -f $WEBUSER_HOME/artisan ]; then
         ############################################################################
         # Automated database migrations
         ############################################################################
-        if [ grep -q DB_DATABASE $WEBUSER_HOME/.env ] && [ ${AUTORUN_LARAVEL_MIGRATION:="false"} == "true" ]; then
+        if [ "grep -q DB_DATABASE $WEBUSER_HOME/.env" ] && [ ${AUTORUN_LARAVEL_MIGRATION:="false"} == "true" ]; then
             echo "🚀 Running migrations..."
             su - webuser -c "php $WEBUSER_HOME/artisan migrate --force"
         fi

--- a/templates/fpm/etc/cont-init.d/50-laravel-automations
+++ b/templates/fpm/etc/cont-init.d/50-laravel-automations
@@ -11,23 +11,12 @@ if [ -f $WEBUSER_HOME/artisan ]; then
     APP_ENV_SETTING=$(cat $WEBUSER_HOME/.env | grep APP_ENV | cut -f2 -d"=")
 
     # If Laravel is not running in development or CI, then automate some production tasks
-    if [ "$APP_ENV_SETTING" != "local" ] && [ ! -z $APP_ENV_SETTING ] && [ ${CI_ENV:="false"} != "true" ] && [ ${RUN_LARAVEL_AUTOMATIONS:="true"} == "true" ]; then
-
-        # ############################################################################
-        # # Cache management - commented out for now because of a bug with Laravel caching & API Rate limiting
-        # ############################################################################
-        # echo "♻️ Refreshing cache..."
-        # # Clear cache
-        # su - webuser -c "php $WEBUSER_HOME/artisan cache:clear"
-
-        # # Set cache
-        # su - webuser -c "php $WEBUSER_HOME/artisan route:cache"
-        # su - webuser -c "php $WEBUSER_HOME/artisan view:cache"
+    if [ "$APP_ENV_SETTING" != "local" ] && [ ! -z $APP_ENV_SETTING ] && [ ${CI_ENV:="false"} != "true" ]; then
 
         ############################################################################
         # Automated database migrations
         ############################################################################
-        if grep -q DB_DATABASE $WEBUSER_HOME/.env; then
+        if [ grep -q DB_DATABASE $WEBUSER_HOME/.env ] && [ ${AUTORUN_LARAVEL_MIGRATION:="false"} == "true" ]; then
             echo "🚀 Running migrations..."
             su - webuser -c "php $WEBUSER_HOME/artisan migrate --force"
         fi
@@ -35,9 +24,25 @@ if [ -f $WEBUSER_HOME/artisan ]; then
         ############################################################################
         # Automated storage linking
         ############################################################################
-        echo "🔐 Linking the storage..."
-        su - webuser -c "php $WEBUSER_HOME/artisan storage:link"
+        if [ ${AUTORUN_LARAVEL_STORAGE_LINK:="true"} == "true" ]; then
+            echo "🔐 Linking the storage..."
+            su - webuser -c "php $WEBUSER_HOME/artisan storage:link"
+        fi
+
+        ############################################################################
+        # Cache management - commented out for now because of a bug with Laravel caching & API Rate limiting
+        ############################################################################
+        # if [ ${AUTORUN_LARAVEL_REFRESH_CACHE:="true"} == "true" ]; then
+        #     echo "♻️ Refreshing cache..."
+        #     # Clear cache
+        #     su - webuser -c "php $WEBUSER_HOME/artisan cache:clear"
+
+        #     # Set cache
+        #     su - webuser -c "php $WEBUSER_HOME/artisan route:cache"
+        #     su - webuser -c "php $WEBUSER_HOME/artisan view:cache"
+        # fi
+
     else
-        echo "👉 Skipping Laravel production commands because the env is set to 'local', running in CI, or explicitly disabled..."
+        echo "👉 Skipping Laravel automations because the env is set to 'local' or running in CI..."
     fi
 fi


### PR DESCRIPTION
# Problem
* `RUN_LARAVEL_AUTOMATIONS` is defaulted to `true`, which is not ideal for large environments
* Changing `RUN_LARAVEL_AUTOMATIONS` to `false` will disable other important features for containers

# Proposed solution
- [x] Remove the `RUN_LARAVEL_AUTOMATIONS` variable
- [x] Create a new variable called `AUTORUN_LARAVEL_MIGRATION` and default it to `false`
- [x] Create a new variable called `AUTORUN_LARAVEL_STORAGE_LINK` and default it to `true`
- [x] Update README with new variables
- [ ] Publish important note to users in new release (expected, **v1.1.0**)