### PR TITLE
Add upstream channel for beta process

### DIFF
--- a/generated-dockerfiles/7.4/cli/Dockerfile
+++ b/generated-dockerfiles/7.4/cli/Dockerfile
@@ -5,7 +5,11 @@
 # Server Side Up -  PHP 7.4 / CLI image 
 #####################################################
 
-FROM serversideup/docker-baseimage-s6-overlay-ubuntu:20.04
+# Default upstream channel to `null` so we default pulling `serversideup/docker-baseimage-s6-overlay-ubuntu:20.04`
+# but can also pull the beta image from `serversideup/docker-baseimage-s6-overlay-ubuntu:beta-20.04`
+ARG  UPSTREAM_CHANNEL=''
+
+FROM serversideup/${UPSTREAM_CHANNEL}docker-baseimage-s6-overlay-ubuntu:20.04
 
 LABEL maintainer="Jay Rogers (@jaydrogers)"
 

--- a/generated-dockerfiles/8.0/cli/Dockerfile
+++ b/generated-dockerfiles/8.0/cli/Dockerfile
@@ -5,7 +5,11 @@
 # Server Side Up -  PHP 8.0 / CLI image 
 #####################################################
 
-FROM serversideup/docker-baseimage-s6-overlay-ubuntu:20.04
+# Default upstream channel to `null` so we default pulling `serversideup/docker-baseimage-s6-overlay-ubuntu:20.04`
+# but can also pull the beta image from `serversideup/docker-baseimage-s6-overlay-ubuntu:beta-20.04`
+ARG  UPSTREAM_CHANNEL=''
+
+FROM serversideup/${UPSTREAM_CHANNEL}docker-baseimage-s6-overlay-ubuntu:20.04
 
 LABEL maintainer="Jay Rogers (@jaydrogers)"
 

--- a/generated-dockerfiles/8.1/cli/Dockerfile
+++ b/generated-dockerfiles/8.1/cli/Dockerfile
@@ -5,7 +5,11 @@
 # Server Side Up -  PHP 8.1 / CLI image 
 #####################################################
 
-FROM serversideup/docker-baseimage-s6-overlay-ubuntu:20.04
+# Default upstream channel to `null` so we default pulling `serversideup/docker-baseimage-s6-overlay-ubuntu:20.04`
+# but can also pull the beta image from `serversideup/docker-baseimage-s6-overlay-ubuntu:beta-20.04`
+ARG  UPSTREAM_CHANNEL=''
+
+FROM serversideup/${UPSTREAM_CHANNEL}docker-baseimage-s6-overlay-ubuntu:20.04
 
 LABEL maintainer="Jay Rogers (@jaydrogers)"
 

--- a/templates/cli/Dockerfile.j2
+++ b/templates/cli/Dockerfile.j2
@@ -4,7 +4,11 @@
 # Server Side Up -  PHP {{ php_version }} / CLI image 
 #####################################################
 
-FROM serversideup/docker-baseimage-s6-overlay-ubuntu:20.04
+# Default upstream channel to `null` so we default pulling `serversideup/docker-baseimage-s6-overlay-ubuntu:20.04`
+# but can also pull the beta image from `serversideup/docker-baseimage-s6-overlay-ubuntu:beta-20.04`
+ARG  UPSTREAM_CHANNEL=''
+
+FROM serversideup/${UPSTREAM_CHANNEL}docker-baseimage-s6-overlay-ubuntu:20.04
 
 LABEL maintainer="Jay Rogers (@jaydrogers)"
 


### PR DESCRIPTION
# Problem
* All images pull from `serversideup/docker-baseimage-s6-overlay-ubuntu:20.04`
* This makes it very difficult to test new versions of S6 Overlay

# Propose solution
- [x] Add `UPSTREAM_CHANNEL` to the `FROM` command so images can be pulled from the "beta" channel