### PR TITLE
update examples to declare commands in list manner

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,9 @@ services:
 
   task:
     image: my/laravel-app
-      # Switch to "webuser" before running `php artisan`
-    command: "su - webuser -c \"php artisan schedule:work\""
+    # Switch to "webuser" before running `php artisan`
+    # Declare command in list manner for environment variable expansion
+    command: ["su", "webuser", "-c", "php artisan schedule:work"]
     environment:
       PHP_POOL_NAME: "my-app_task"
 ```
@@ -170,7 +171,8 @@ services:
   queue:
     image: my/laravel-app
     # Switch to "webuser" before running `php artisan`
-    command: "su - webuser -c \"php artisan queue:work --tries=3\""
+    # Declare command in list manner for environment variable expansion
+    command: ["su", "webuser", "-c", "php artisan queue:work --tries=3"]
     environment:
       PHP_POOL_NAME: "my-app_queue"
 ```
@@ -199,7 +201,8 @@ services:
   horizon:
     image: my/laravel-app
     # Switch to "webuser" before running `php artisan`
-    command: "su - webuser -c \"php artisan horizon\""
+    # Declare command in list manner for environment variable expansion
+    command: ["su", "webuser", "-c", "php artisan horizon"]
     environment:
       PHP_POOL_NAME: "my-app_horizon"
 ```


### PR DESCRIPTION
# Problem
when running a container with a command in _shell_ form the passed environmental variables are not  available because the command is executed by the shell and environment variable expansion will be done by the  shell, not docker. 

[Docker Documentation](https://docs.docker.com/engine/reference/builder/#cmd)

If you declare environmental variables f.e. the `REDIS_HOST` or `DB_HOST` variable in your docker-compose and then run your queue worker, the queue worker won't be using these set variables but instead the variables present to the shell.


# Solution
By writing the command in the _list_ or _array form_, the passed environmental variables will be present at runtime of the command. Furthermore, docker declares the _array form_ as its preferred format of  `CMD`. This change hence follows best practices from docker.