### PR TITLE
add php intl package to support laravel email validation rules

### DIFF
--- a/variables.yaml
+++ b/variables.yaml
@@ -12,6 +12,7 @@ versions:
       - php7.4-soap
       - php7.4-sqlite3
       - php7.4-xml
+      - php7.4-intl
       - php7.4-zip
   8.0:
     packages:
@@ -25,6 +26,7 @@ versions:
       - php8.0-soap
       - php8.0-sqlite3
       - php8.0-xml
+      - php8.0-intl
       - php8.0-zip
   8.1:
     packages:
@@ -38,6 +40,7 @@ versions:
       - php8.1-soap
       - php8.1-sqlite3
       - php8.1-xml
+      - php8.1-intl
       - php8.1-zip
 
 


### PR DESCRIPTION
Hello!

Thanks for this great repository.

While using Laravel's [email validation rules](https://laravel.com/docs/9.x/validation#rule-email) I end up with an exception because the underlying package that they use requires the intl package to be installed.

I created a custom Docker image, but I figured I would submit this as a PR since these images are tuned for Laravel.