### PR TITLE
Allow Custom Apache VHOST directives to be included

### DIFF
--- a/src/fpm-apache/etc/apache2/custom-vhost-conf/example.conf
+++ b/src/fpm-apache/etc/apache2/custom-vhost-conf/example.conf
@@ -1,0 +1,3 @@
+# Place any custom configurations in the 'custom-vhost-conf' directory.
+
+# Any configurations ending in '.conf' will be loaded within the virtual host directive.

--- a/src/fpm-apache/etc/apache2/sites-available/ssl-full.conf
+++ b/src/fpm-apache/etc/apache2/sites-available/ssl-full.conf
@@ -19,5 +19,6 @@
 </VirtualHost>
 
 <VirtualHost *:443>
+    Include /etc/apache2/custom-vhost-conf/*.conf
     Include /etc/apache2/vhost-templates/https.conf
 </VirtualHost>

--- a/src/fpm-apache/etc/apache2/sites-available/ssl-mixed.conf
+++ b/src/fpm-apache/etc/apache2/sites-available/ssl-mixed.conf
@@ -1,7 +1,9 @@
 <VirtualHost *:80>
+    Include /etc/apache2/custom-vhost-conf/*.conf
     Include /etc/apache2/vhost-templates/http.conf
 </VirtualHost>
 
 <VirtualHost *:443>
+    Include /etc/apache2/custom-vhost-conf/*.conf
     Include /etc/apache2/vhost-templates/https.conf
 </VirtualHost>

--- a/src/fpm-apache/etc/apache2/sites-available/ssl-off.conf
+++ b/src/fpm-apache/etc/apache2/sites-available/ssl-off.conf
@@ -1,3 +1,4 @@
 <VirtualHost *:80>
+    Include /etc/apache2/custom-vhost-conf/*.conf
     Include /etc/apache2/vhost-templates/http.conf
 </VirtualHost>


### PR DESCRIPTION
# Problem
- There isn't an easy way to include simple configuration additions to the Apache sites

# What this PR does
- [X] Create a new folder called `/etc/apache2/custom-vhost-conf`
- [X] Set the Apache configurations to scan that folder for any file ending in `*.conf`
- [ ] Include those settings to be loaded within the Virtual Host Directive 