### PR TITLE
Isolate migrations to allow multiple containers

### DIFF
--- a/src/fpm/etc/s6-overlay/scripts/laravel-automations
+++ b/src/fpm/etc/s6-overlay/scripts/laravel-automations
@@ -12,7 +12,7 @@ if [ -f $WEBUSER_HOME/artisan ] && [ ${AUTORUN_ENABLED:="true"} == "true" ]; the
         ############################################################################
         if [ ${AUTORUN_LARAVEL_MIGRATION:="false"} == "true" ]; then
             echo "🚀 Running migrations..."
-            s6-setuidgid webuser php $WEBUSER_HOME/artisan migrate --force
+            s6-setuidgid webuser php $WEBUSER_HOME/artisan migrate --force --isolated
         fi
 
         ############################################################################


### PR DESCRIPTION
Adding the `--isolated` flag will allow `AUTORUN_LARAVEL_MIGRATION=true` to be useful in a clustered setup. If multiple containers are launched simultaneously, the first will grab a DB lock, run the migrations, and the subsequent containers will find the migration already run and not re-run them.

Source: [Laravel: Isolating Migration Execution](https://laravel.com/docs/9.x/migrations#running-migrations).