### PR TITLE
Add better S6 Overlay versioning

### DIFF
--- a/.github/workflows/service_docker-build-and-publish.yml
+++ b/.github/workflows/service_docker-build-and-publish.yml
@@ -5,14 +5,6 @@ on:
         required: true
         type: string
         default: ''
-      base-os-flavor:
-        required: false
-        type: string
-        default: 'ubuntu'
-      base-os-version:
-        required: false
-        type: string
-        default: '22.04'
       tag-prefix:
         required: true
         type: string
@@ -96,8 +88,6 @@ jobs:
         with:
           build-args: |
             UPSTREAM_CHANNEL=${{ inputs.upstream-channel-prefix }}
-            BASE_OS_FLAVOR=${{ inputs.base-os-flavor }}
-            BASE_OS_VERSION=${{ inputs.base-os-version }}
             PHP_VERSION=${{ matrix.php-version }}
           context: src/${{ inputs.php-variation }}/.
           platforms: |

--- a/dev.sh
+++ b/dev.sh
@@ -6,8 +6,6 @@ set -e
 ##########################
 # Environment Settings
 DEV_UPSTREAM_CHANNEL="beta-"
-DEV_BASE_OS_FLAVOR="ubuntu"
-DEV_BASE_OS_VERSION="22.04"
 
 # UI Colors
 function ui_set_yellow {
@@ -33,12 +31,19 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # Set versions to build
 if [ $# -eq 0 ]; then
     # Set versions
-    phpVersions=(
-        7.4
-        8.0
-        8.1
-        8.2
-    )
+    phpVersions=()
+
+    echo "Running build for these PHP versions..."
+    # Loop through each .txt file in the current directory
+    for file in src/cli/php-version-packages/*.txt; do
+        # Trim the extension off the filename and add it to the array
+        phpVersion=$(basename -- "$file")
+        phpVersion="${phpVersion%.*}"
+        phpVersions+=("$phpVersion")
+
+        # Print the filename without the extension
+        echo "$phpVersion"
+    done
 else
     phpVersions=$1
 fi
@@ -53,8 +58,6 @@ function build (){
         # Use "docker build"
         docker build \
             --build-arg UPSTREAM_CHANNEL="${DEV_UPSTREAM_CHANNEL}" \
-            --build-arg BASE_OS_FLAVOR="${DEV_BASE_OS_FLAVOR}" \
-            --build-arg BASE_OS_VERSION="${DEV_BASE_OS_VERSION}" \
             --build-arg PHP_VERSION="${2}" \
             -t "serversideup/php:beta-${2}-$1" \
             $SCRIPT_DIR/src/$1/

--- a/src/cli/Dockerfile
+++ b/src/cli/Dockerfile
@@ -1,7 +1,8 @@
 ARG UPSTREAM_CHANNEL=''
 ARG BASE_OS_FLAVOR='ubuntu'
 ARG BASE_OS_VERSION='22.04'
-ARG BASE_IMAGE="serversideup/s6-overlay:${UPSTREAM_CHANNEL}${BASE_OS_FLAVOR}-${BASE_OS_VERSION}"
+ARG S6_OVERLAY_VERSION='v3.1.2.1'
+ARG BASE_IMAGE="serversideup/s6-overlay:${UPSTREAM_CHANNEL}${BASE_OS_FLAVOR}-${BASE_OS_VERSION}-${S6_OVERLAY_VERSION}"
 
 # add ondrej repository
 FROM ${BASE_IMAGE} as repo-config
@@ -14,7 +15,7 @@ RUN apt-get update \
 FROM ${BASE_IMAGE}
 LABEL maintainer="Jay Rogers (@jaydrogers)"
 
-ARG PHP_VERSION='8.1'
+ARG PHP_VERSION='8.2'
 
 ENV BUILD_PHP_VERSION=$PHP_VERSION \
     DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
# Problem
- The upstream images were not explicit with what version of S6 overlay was being used

# What this PR does
- This PR sets an explicit version of S6 Overlay that can be modified in the `src/cli/Dockerfile` file