### PR TITLE
Use ondrej/nginx and brotli

### DIFF
--- a/src/fpm-nginx/Dockerfile
+++ b/src/fpm-nginx/Dockerfile
@@ -2,6 +2,12 @@ ARG  UPSTREAM_CHANNEL=''
 ARG PHP_VERSION='8.2'
 ARG BASE_IMAGE="serversideup/php:${UPSTREAM_CHANNEL}${PHP_VERSION}-fpm"
 
+FROM ${BASE_IMAGE} as repo-config
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gnupg2 ca-certificates software-properties-common \
+    && add-apt-repository -y ppa:ondrej/nginx
+
 FROM ${BASE_IMAGE}
 
 LABEL maintainer="Jay Rogers (@jaydrogers)"
@@ -15,6 +21,9 @@ ENV MSMTP_RELAY_SERVER_HOSTNAME="mailhog" \
     PHP_PM_MIN_SPARE_SERVERS="1" \
     PHP_PM_MAX_SPARE_SERVERS="3" \
     SSL_MODE="full"
+    
+COPY --from=repo-config /etc/apt/sources.list.d/ /etc/apt/sources.list.d/
+COPY --from=repo-config /etc/apt/trusted.gpg.d/ondrej-ubuntu-nginx.gpg /etc/apt/trusted.gpg.d/ondrej-ubuntu-nginx.gpg
 
 # install`nginx` (web server) & `msmtp` (smtp client)
 RUN apt-get update \

--- a/src/fpm-nginx/etc/nginx/nginx.conf
+++ b/src/fpm-nginx/etc/nginx/nginx.conf
@@ -2,6 +2,9 @@ user webuser webgroup;
 worker_processes auto;
 pid /run/nginx.pid;
 daemon off;
+load_module modules/ngx_http_brotli_filter_module.so;
+load_module modules/ngx_http_brotli_static_module.so;
+
 
 events {
 	worker_connections 768;
@@ -44,8 +47,7 @@ http {
 	##
 	# Increase header size for better support on Laravel APIs
 	##
-	http2_max_field_size 16k;
-	http2_max_header_size 32k;
+	large_client_header_buffers 4 16k;
 
 	##
 	# Virtual Host Configs

--- a/src/fpm-nginx/etc/nginx/server-opts.d/performance.conf
+++ b/src/fpm-nginx/etc/nginx/server-opts.d/performance.conf
@@ -36,4 +36,8 @@ gzip_types      text/plain text/css text/xml application/json application/javasc
 # brotli
 brotli on;
 brotli_comp_level 6;
-brotli_types text/xml image/svg+xml application/x-font-ttf image/vnd.microsoft.icon application/x-font-opentype application/json font/eot application/vnd.ms-fontobject application/javascript font/otf application/xml application/xhtml+xml text/javascript  application/x-javascript text/plain application/x-font-truetype application/xml+rss image/x-icon font/opentype text/css image/x-win-bitmap;
+application/atom+xml application/javascript application/json application/rss+xml
+             application/vnd.ms-fontobject application/x-font-opentype application/x-font-truetype
+             application/x-font-ttf application/x-javascript application/xhtml+xml application/xml
+             font/eot font/opentype font/otf font/truetype image/svg+xml image/vnd.microsoft.icon
+             image/x-icon image/x-win-bitmap text/css text/javascript text/plain text/xml;

--- a/src/fpm-nginx/etc/nginx/server-opts.d/performance.conf
+++ b/src/fpm-nginx/etc/nginx/server-opts.d/performance.conf
@@ -32,3 +32,8 @@ gzip_vary       on;
 gzip_proxied    any;
 gzip_comp_level 6;
 gzip_types      text/plain text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;
+
+# brotli
+brotli on;
+brotli_comp_level 6;
+brotli_types text/xml image/svg+xml application/x-font-ttf image/vnd.microsoft.icon application/x-font-opentype application/json font/eot application/vnd.ms-fontobject application/javascript font/otf application/xml application/xhtml+xml text/javascript  application/x-javascript text/plain application/x-font-truetype application/xml+rss image/x-icon font/opentype text/css image/x-win-bitmap;


### PR DESCRIPTION
Since you are using the php ondrej repos , might as well use the nginx ones too.
The ppa of ondrej/nginx has more features and is up to date with the stable version of nginx.
More specifically it includes support for Brotli.
This PR installs the nginx from ondrej and enables the Brotli support for all compatible types. 