### PR TITLE
Fix storage linking issue (#193)

### DIFF
--- a/src/fpm/etc/s6-overlay/scripts/laravel-automations
+++ b/src/fpm/etc/s6-overlay/scripts/laravel-automations
@@ -19,8 +19,12 @@ if [ -f $WEBUSER_HOME/artisan ] && [ ${AUTORUN_ENABLED:="true"} == "true" ]; the
         # Automated storage linking
         ############################################################################
         if [ ${AUTORUN_LARAVEL_STORAGE_LINK:="true"} == "true" ]; then
-            echo "🔐 Linking the storage..."
-            s6-setuidgid webuser php $WEBUSER_HOME/artisan storage:link
+            if [ -d $WEBUSER_HOME/public/storage ]; then
+                echo "✅ Storage already linked..."
+            else
+                echo "🔐 Linking the storage..."
+                s6-setuidgid webuser php $WEBUSER_HOME/artisan storage:link
+            fi
         fi
 else
     echo "👉 Skipping Laravel automations because we could not detect a Laravel install or it was specifically disabled..."


### PR DESCRIPTION
### What this PR does
This PR fixes #193. It changes the logic to check for the existence of the linked storage in Laravel.

If it is already exists, it does not attempt to run the `storage:link` command -- preventing the error from displaying.