### PR TITLE
Optional migration isolation

### DIFF
--- a/src/common/etc/entrypoint.d/50-laravel-automations.sh
+++ b/src/common/etc/entrypoint.d/50-laravel-automations.sh
@@ -29,6 +29,7 @@ test_db_connection() {
 # Set default values for Laravel automations
 : "${AUTORUN_ENABLED:=false}"
 : "${AUTORUN_LARAVEL_MIGRATION_TIMEOUT:=30}"
+: "${AUTORUN_LARAVEL_MIGRATION_ISOLATION:true}"
 
 if [ "$DISABLE_DEFAULT_CONFIG" = "false" ]; then
     # Check to see if an Artisan file exists and assume it means Laravel is configured.
@@ -59,7 +60,8 @@ if [ "$DISABLE_DEFAULT_CONFIG" = "false" ]; then
             fi
 
             echo "🚀 Running migrations..."
-            php "$APP_BASE_DIR/artisan" migrate --force --isolated
+            isolated=$([ "${AUTORUN_LARAVEL_MIGRATION_ISOLATION:=true}" = "true" ] && echo "--isolated" || echo "")
+            php "$APP_BASE_DIR/artisan" migrate --force $isolated
         fi
 
         ############################################################################

--- a/src/common/etc/entrypoint.d/50-laravel-automations.sh
+++ b/src/common/etc/entrypoint.d/50-laravel-automations.sh
@@ -29,7 +29,6 @@ test_db_connection() {
 # Set default values for Laravel automations
 : "${AUTORUN_ENABLED:=false}"
 : "${AUTORUN_LARAVEL_MIGRATION_TIMEOUT:=30}"
-: "${AUTORUN_LARAVEL_MIGRATION_ISOLATION:true}"
 
 if [ "$DISABLE_DEFAULT_CONFIG" = "false" ]; then
     # Check to see if an Artisan file exists and assume it means Laravel is configured.


### PR DESCRIPTION
Implementing one way of resolving the issue outlined at https://github.com/serversideup/docker-php/issues/298 by introducing a new environment variable `AUTORUN_LARAVEL_MIGRATION_ISOLATION`. 
It is enabled by default because the issue is only with the database cache driver.