### PR TITLE
Improve Laravel Migration support for SQLite & Laravel 11

### DIFF
--- a/docs/content/docs/6.reference/1.environment-variable-specification.md
+++ b/docs/content/docs/6.reference/1.environment-variable-specification.md
@@ -21,13 +21,14 @@ We like to customize our images on a per app basis using environment variables. 
 `APACHE_THREADS_PER_CHILD`<br />*Default: "25"*|This directive sets the number of threads created by each child process. (<a target="_blank" href="https://httpd.apache.org/docs/2.4/mod/mpm_common.html#threadsperchild">Official docs</a>)|fpm-apache
 `APP_BASE_DIR`<br />*Default: "/var/www/html"*|Change this only if you mount your application to a different directory within the container.|all
 `AUTORUN_ENABLED`<br />*Default: "false"*|Enable or disable all automations. It's advised to set this to `false` in certain CI environments (especially during a composer install). If this is set to `false`, all `AUTORUN_*` behaviors will also be disabled.| all
-`AUTORUN_LARAVEL_CONFIG_CACHE`<br />*⚠️ Depends on: `AUTORUN_ENABLED`*<br />*Default: "true"*|Automatically run "php artisan config:cache" on container start| all
-`AUTORUN_LARAVEL_EVENT_CACHE`<br />*⚠️ Depends on: `AUTORUN_ENABLED`*<br />*Default: "true"*|Automatically run "php artisan event:cache" on container start| all
-`AUTORUN_LARAVEL_MIGRATION`<br />*⚠️ Depends on: `AUTORUN_ENABLED`*<br />*Default: "true"*|Requires Laravel v9.38.0 or higher. Automatically run "php artisan migrate --force --isolated" on container start.| all
-`AUTORUN_LARAVEL_MIGRATION_TIMEOUT`<br />*⚠️ Depends on: `AUTORUN_ENABLED`*<br />*Default: "30"*|The number of seconds to wait for the database to come online before attempting `php artisan migrate`.| all
-`AUTORUN_LARAVEL_ROUTE_CACHE`<br />*⚠️ Depends on: `AUTORUN_ENABLED`*<br />*Default: "true"*|Automatically run "php artisan route:cache" on container start| all
-`AUTORUN_LARAVEL_STORAGE_LINK`<br />*⚠️ Depends on: `AUTORUN_ENABLED`*<br />*Default: "true"*|Automatically run "php artisan storage:link" on container start| all
-`AUTORUN_LARAVEL_VIEW_CACHE`<br />*⚠️ Depends on: `AUTORUN_ENABLED`*<br />*Default: "true"*|Automatically run "php artisan view:cache" on container start| all
+`AUTORUN_LARAVEL_CONFIG_CACHE`<br />*Default: "true"*|Automatically run "php artisan config:cache" on container start. <br />ℹ️ Requires `AUTORUN_ENABLED = true` to run.| all
+`AUTORUN_LARAVEL_EVENT_CACHE`<br />*Default: "true"*|Automatically run "php artisan event:cache" on container start. <br />ℹ️ Requires `AUTORUN_ENABLED = true` to run.| all
+`AUTORUN_LARAVEL_MIGRATION`<br />*Default: "true"*|Automatically run `php artisan migrate --force` on container start.  <br />ℹ️ Requires `AUTORUN_ENABLED = true` to run.| all
+`AUTORUN_LARAVEL_MIGRATION_ISOLATION`<br />*Default: "false"*|Requires Laravel v9.38.0 or higher and a database that supports table locks. Automatically run `php artisan migrate --force --isolated` on container start. <br /><br />ℹ️ Requires `AUTORUN_ENABLED = true` to run.<br />ℹ️ Does not work with SQLite.| all
+`AUTORUN_LARAVEL_MIGRATION_TIMEOUT`<br />*Default: "30"*|The number of seconds to wait for the database to come online before attempting `php artisan migrate`.. <br />ℹ️ Requires `AUTORUN_ENABLED = true` to run.| all
+`AUTORUN_LARAVEL_ROUTE_CACHE`<br />*Default: "true"*|Automatically run "php artisan route:cache" on container start. <br />ℹ️ Requires `AUTORUN_ENABLED = true` to run.| all
+`AUTORUN_LARAVEL_STORAGE_LINK`<br />*Default: "true"*|Automatically run "php artisan storage:link" on container start. <br />ℹ️ Requires `AUTORUN_ENABLED = true` to run.| all
+`AUTORUN_LARAVEL_VIEW_CACHE`<br />*Default: "true"*|Automatically run "php artisan view:cache" on container start. <br />ℹ️ Requires `AUTORUN_ENABLED = true` to run.| all
 `COMPOSER_ALLOW_SUPERUSER`<br />*Default: "1"*|Disable warning about running as super-user|all
 `COMPOSER_HOME`<br />*Default: "/composer"*|The COMPOSER_HOME variable allows you to change the Composer home directory. This is a hidden, global (per-user on the machine) directory that is shared between all projects.|all
 `COMPOSER_MAX_PARALLEL_HTTP`<br />*Default: "24"*|Set to an integer to configure how many files can be downloaded in parallel. Composer ships with 12 by default and must be between 1 and 50. If your proxy has issues with concurrency maybe you want to lower this. Increasing it should generally not result in performance gains.|all

--- a/src/common/etc/entrypoint.d/50-laravel-automations.sh
+++ b/src/common/etc/entrypoint.d/50-laravel-automations.sh
@@ -59,7 +59,8 @@ if [ "$DISABLE_DEFAULT_CONFIG" = "false" ]; then
             fi
 
             echo "🚀 Running migrations..."
-            php "$APP_BASE_DIR/artisan" migrate --force --isolated
+            isolated=$([ "${AUTORUN_LARAVEL_MIGRATION_ISOLATION:=true}" = "true" ] && echo "--isolated" || echo "")
+            php "$APP_BASE_DIR/artisan" migrate --force $isolated
         fi
 
         ############################################################################

--- a/src/common/etc/entrypoint.d/50-laravel-automations.sh
+++ b/src/common/etc/entrypoint.d/50-laravel-automations.sh
@@ -10,6 +10,13 @@ test_db_connection() {
         \$kernel = \$app->make(Illuminate\Contracts\Console\Kernel::class);
         \$kernel->bootstrap();
 
+        \$driver = DB::getDriverName();
+
+            if( \$driver === 'sqlite' ){
+                echo 'SQLite detected';
+                exit(0); // Assume SQLite is always ready
+            }
+
         try {
             DB::connection()->getPdo(); // Attempt to get PDO instance
             if (DB::connection()->getDatabaseName()) {
@@ -59,8 +66,11 @@ if [ "$DISABLE_DEFAULT_CONFIG" = "false" ]; then
             fi
 
             echo "🚀 Running migrations..."
-            isolated=$([ "${AUTORUN_LARAVEL_MIGRATION_ISOLATION:=true}" = "true" ] && echo "--isolated" || echo "")
-            php "$APP_BASE_DIR/artisan" migrate --force $isolated
+            if [ "${AUTORUN_LARAVEL_MIGRATION_ISOLATION:=false}" = "true" ]; then
+                php "$APP_BASE_DIR/artisan" migrate --force --isolated
+            else
+                php "$APP_BASE_DIR/artisan" migrate --force
+            fi
         fi
 
         ############################################################################


### PR DESCRIPTION
## What this PR Does
This PR fixes issues assuming the user is running a database that uses Database locks.

The following improvements are made:
- [x] Adjust the migrations to have "isolations" OFF by default
- [x] Allow isolations to be enabled if wanted
- [x] Update docs to reflect this change

## Fixes
- #298

## Original author
@ivandokov