### PR TITLE
Set default NGINX values for "fastcgi_buffers" and "fastcgi_buffer_size"

### DIFF
--- a/src/variations/fpm-nginx/etc/nginx/site-opts.d/http.conf.template
+++ b/src/variations/fpm-nginx/etc/nginx/site-opts.d/http.conf.template
@@ -37,6 +37,8 @@ location ~ \.php$ {
     fastcgi_index  index.php;
     fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
     include        fastcgi_params;
+    fastcgi_buffers 8 8k; 
+    fastcgi_buffer_size 8k;
 }
 
 # additional config

--- a/src/variations/fpm-nginx/etc/nginx/site-opts.d/https.conf.template
+++ b/src/variations/fpm-nginx/etc/nginx/site-opts.d/https.conf.template
@@ -42,6 +42,8 @@ location ~ \.php$ {
     fastcgi_index  index.php;
     fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
     include        fastcgi_params;
+    fastcgi_buffers 8 8k; 
+    fastcgi_buffer_size 8k;
 }
 
 # additional config


### PR DESCRIPTION
# Fixes
- #304 

# What this PR does
- Set `fastcgi_buffers` to `8 8k`
- Set `fastcgi_buffer_size` to `8k