### PR TITLE
Add check for Unit custom certs

### DIFF
--- a/src/variations/unit/etc/entrypoint.d/10-init-unit.sh
+++ b/src/variations/unit/etc/entrypoint.d/10-init-unit.sh
@@ -161,6 +161,13 @@ validate_ssl(){
         return 0
     fi
 
+    custom_ssl=$(/usr/bin/find "/etc/ssl/private" -type f -name "$UNIT_CERTIFICATE_NAME.crt")
+    if [ -n "$custom_ssl" ]; then
+        echo "ℹ️ NOTICE ($script_name): Custom SSL Certificate found in /etc/sss/private, so we'll use that."
+        cat "/etc/ssl/private/$UNIT_CERTIFICATE_NAME.key" "/etc/ssl/private/$UNIT_CERTIFICATE_NAME.crt" > "$UNIT_CONFIG_DIRECTORY/$UNIT_CERTIFICATE_NAME.pem"
+        return 0
+    fi
+
     echo "$script_name: 🔐 SSL Certbundle not found. Generating self-signed SSL bundle..."
     mkdir -p /etc/ssl/private/
     openssl req -x509 -subj "/C=US/ST=Wisconsin/L=Milwaukee/O=IT/CN=default.test" -nodes -newkey rsa:2048 -keyout "/etc/ssl/private/$UNIT_CERTIFICATE_NAME.key" -out "/etc/ssl/private/$UNIT_CERTIFICATE_NAME.crt" -days 365 >/dev/null 2>&1

--- a/src/variations/unit/etc/entrypoint.d/10-init-unit.sh
+++ b/src/variations/unit/etc/entrypoint.d/10-init-unit.sh
@@ -161,8 +161,7 @@ validate_ssl(){
         return 0
     fi
 
-    custom_ssl=$(/usr/bin/find "/etc/ssl/private" -type f -name "$UNIT_CERTIFICATE_NAME.crt")
-    if [ -n "$custom_ssl" ]; then
+    if [ -f "/etc/ssl/private/$UNIT_CERTIFICATE_NAME.crt" ] && [ -f "/etc/ssl/private/$UNIT_CERTIFICATE_NAME.key" ]; then
         echo "ℹ️ NOTICE ($script_name): Custom SSL Certificate found in /etc/sss/private, so we'll use that."
         cat "/etc/ssl/private/$UNIT_CERTIFICATE_NAME.key" "/etc/ssl/private/$UNIT_CERTIFICATE_NAME.crt" > "$UNIT_CONFIG_DIRECTORY/$UNIT_CERTIFICATE_NAME.pem"
         return 0


### PR DESCRIPTION
I'm not convinced we need the first check on line 157 at all as I don't know how a cert would ever get into the config directory at this stage. However, maybe it is useful if someone is building a custom image and copying their SSL directly into the config directory. So I've left it in place.

However, we previously then went straight to creating the self signed cert, without ever actually taking a look inside /etc/ssl/private to see if there was a custom cert in there. So this PR basically adds that check to use a custom cert if provided before moving on to generating a self signed.