### PR TITLE
Change to upload to GHCR for PRs only

### DIFF
--- a/.github/workflows/action_publish-images-dev.yml
+++ b/.github/workflows/action_publish-images-dev.yml
@@ -23,9 +23,10 @@ jobs:
     uses: ./.github/workflows/service_docker-build-and-publish.yml
     with:
       # Set to our development repository
-      registry-repositories: "docker.io/serversideup/php-dev"
+      registry-repositories: "ghcr.io/${{ github.repository }}"
       # Set to the pull request number for PRs, or no prefix for main branch
-      tag-prefix: ${{ github.event_name == 'pull_request' && format('{0}-', github.event.pull_request.number) || '' }}
+      tag-prefix: ${{ github.event_name == 'pull_request' && format('dev-{0}-', github.event.pull_request.number) || 'dev' }}
       # Set release type to "latest" for our development if on main, otherwise default to testing
       release-type: ${{ github.ref == 'refs/heads/main' && 'latest' || 'testing' }}
+      authenticate_with_dockerhub: false
     secrets: inherit

--- a/.github/workflows/action_publish-images-testing.yml
+++ b/.github/workflows/action_publish-images-testing.yml
@@ -23,9 +23,9 @@ jobs:
     uses: ./.github/workflows/service_docker-build-and-publish.yml
     with:
       # Set to our development repository
-      registry-repositories: "ghcr.io/${{ github.repository }}"
+      registry-repositories: "ghcr.io/${{ github.repository_owner }}/php-testing"
       # Set to the pull request number for PRs, or no prefix for main branch
-      tag-prefix: ${{ github.event_name == 'pull_request' && format('dev-{0}-', github.event.pull_request.number) || 'dev' }}
+      tag-prefix: ${{ github.event_name == 'pull_request' && format('{0}-', github.event.pull_request.number) || '' }}
       # Set release type to "latest" for our development if on main, otherwise default to testing
       release-type: ${{ github.ref == 'refs/heads/main' && 'latest' || 'testing' }}
       authenticate_with_dockerhub: false

--- a/.github/workflows/service_docker-build-and-publish.yml
+++ b/.github/workflows/service_docker-build-and-publish.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      authenticate_with_dockerhub:
+        default: true
+        type: boolean
+        description: 'Whether to authenticate with DockerHub.'
       tag-prefix:
         required: true
         type: string
@@ -85,6 +89,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+        if: ${{ inputs.authenticate_with_dockerhub }} == true
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
### What this PR does
- It removes the requirements for a user needing to have a DockerHub account to submit a PR with an automated build