### PR TITLE
Resolve Unit Port Expose Settings & Upgrade PHP Extension Installer to 2.2.14

### DIFF
--- a/src/common/usr/local/bin/docker-php-serversideup-install-php-ext-installer
+++ b/src/common/usr/local/bin/docker-php-serversideup-install-php-ext-installer
@@ -11,7 +11,7 @@ script_name="docker-php-serversideup-install-php-ext-installer"
 ############
 # Environment variables
 ############
-PHP_EXT_INSTALLER_VERSION="2.2.6"
+PHP_EXT_INSTALLER_VERSION="2.2.14"
 
 ############
 # Main

--- a/src/variations/unit/Dockerfile
+++ b/src/variations/unit/Dockerfile
@@ -148,8 +148,6 @@ RUN docker-php-serversideup-dep-install-alpine "${DEPENDENCY_PACKAGES_ALPINE}" &
     # Install default PHP extensions
     install-php-extensions "${DEPENDENCY_PHP_EXTENSIONS}"
 
-EXPOSE 80 443
-
 ENTRYPOINT ["docker-php-serversideup-entrypoint"]
 
 STOPSIGNAL SIGTERM


### PR DESCRIPTION
### What this PR does
- Removes old `EXPOSE` command in NGINX Unit
- Upgrades to latest version of the PHP Extension installer

### Fixes
- https://github.com/serversideup/docker-php/issues/355