### PR TITLE
Improve debug for FPM

### DIFF
--- a/src/common/etc/entrypoint.d/1-debug-mode.sh
+++ b/src/common/etc/entrypoint.d/1-debug-mode.sh
@@ -1,30 +1,85 @@
 #!/bin/sh
 script_name="debug-mode"
 
-if [ "$DISABLE_DEFAULT_CONFIG" = false ]; then
-    set_php_ini (){
-        php_ini_setting=$1
-        php_ini_value=$2
-        php_ini_debug_file="$PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
-        php_fpm_debug_conf_file="/usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf"
-
-        echo "$php_ini_setting = $php_ini_value" >> "$php_ini_debug_file"
-        echo "ℹ️ NOTICE ($script_name): INI - $php_ini_setting has been set to \"$php_ini_value\"."
-
-        # Check for PHP-FPM
-        if [ -d "/usr/local/etc/php-fpm.d" ]; then
-            echo "php_admin_value[$php_ini_setting] = $php_ini_value" >> "$php_fpm_debug_conf_file"
-            echo "ℹ️ NOTICE ($script_name): FPM - $php_ini_setting has been set to \"$php_ini_value\""
-        fi
-    }
-
-    if [ "$LOG_OUTPUT_LEVEL" = "debug" ]; then
-        set_php_ini display_errors On
-        set_php_ini display_startup_errors On
-        set_php_ini error_reporting "32767"
-    fi
-else
+if [ "$DISABLE_DEFAULT_CONFIG" = true ]; then
     if [ "$LOG_OUTPUT_LEVEL" = "debug" ]; then
         echo "👉 $script_name: DISABLE_DEFAULT_CONFIG does not equal \"false\", so debug mode will NOT be automatically set."
     fi
+    exit 0 # Exit if DISABLE_DEFAULT_CONFIG is true
 fi
+
+#######################################
+# Functions
+#######################################
+
+fpm_is_installed (){
+    if [ -d "/usr/local/etc/php-fpm.d" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+set_php_ini (){
+    php_ini_setting=$1
+    php_ini_value=$2
+    php_ini_debug_file="$PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
+    php_fpm_debug_conf_file="/usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf"
+
+    echo "$php_ini_setting = $php_ini_value" >> "$php_ini_debug_file"
+    echo "ℹ️ NOTICE ($script_name): INI - $php_ini_setting has been set to \"$php_ini_value\"."
+
+    # Check for PHP-FPM
+    if fpm_is_installed; then
+        echo "php_admin_value[$php_ini_setting] = $php_ini_value" >> "$php_fpm_debug_conf_file"
+        echo "ℹ️ NOTICE ($script_name): FPM - $php_ini_setting has been set to \"$php_ini_value\""
+    fi
+}
+
+set_fpm_log_level (){
+    if ! fpm_is_installed; then
+        return 0
+    fi
+
+    fpm_log_level=$1
+    sed -i "/\[global\]/a log_level = $fpm_log_level" /usr/local/etc/php-fpm.conf
+    echo "ℹ️ NOTICE ($script_name): FPM - log_level has been set to \"$fpm_log_level\""
+}
+
+#######################################
+# Main (if default config is enabled)
+#######################################
+
+case "$LOG_OUTPUT_LEVEL" in
+    debug)
+    set_php_ini display_errors On
+    set_php_ini display_startup_errors On
+    set_php_ini error_reporting "32767" # E_ALL
+    set_fpm_log_level debug
+    ;;
+    info)
+    set_fpm_log_level notice
+    ;;
+    notice)
+    set_fpm_log_level notice
+    ;;
+    warn)
+    : # Do nothing
+    ;;
+    error)
+    set_fpm_log_level error
+    ;;
+    crit)
+    set_fpm_log_level alert
+    ;;
+    alert)
+    set_fpm_log_level alert
+    ;;
+    emerg)
+    set_fpm_log_level alert
+    ;;
+    *)
+    echo "👉 $script_name: LOG_OUTPUT_LEVEL is not set to a valid value. Please set it to one of the following: debug, info, notice, warn, error, crit, alert, emerg."
+    exit 1
+    ;;
+esac

--- a/src/common/usr/local/bin/docker-php-serversideup-set-file-permissions
+++ b/src/common/usr/local/bin/docker-php-serversideup-set-file-permissions
@@ -82,7 +82,7 @@ case "$OS" in
                 DIRS="/etc/nginx/ /var/log/nginx /etc/ssl/private /var/cache/nginx/ /var/www/ /usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             unit)
-                DIRS="/var/log/unit /var/run/unit /etc/unit /etc/ssl/private/ /var/lib/unit/ /var/www/"
+                DIRS="/var/log/unit /var/run/unit /etc/unit /etc/ssl/private/ /var/lib/unit/ /var/www/ $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             *)
                 echo "$script_name: Unsupported service: $SERVICE"

--- a/src/common/usr/local/bin/docker-php-serversideup-set-file-permissions
+++ b/src/common/usr/local/bin/docker-php-serversideup-set-file-permissions
@@ -73,13 +73,13 @@ case "$OS" in
                 DIRS="/var/www/ $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             fpm)
-                DIRS="/var/www/ /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
+                DIRS="/var/www/ /usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             apache)
-                DIRS="/etc/apache2 /etc/ssl/private /var/log/apache2 /var/www/ /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
+                DIRS="/etc/apache2 /etc/ssl/private /var/log/apache2 /var/www/ /usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             nginx)
-                DIRS="/etc/nginx/ /var/log/nginx /etc/ssl/private /var/cache/nginx/ /var/www/ /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
+                DIRS="/etc/nginx/ /var/log/nginx /etc/ssl/private /var/cache/nginx/ /var/www/ /usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             unit)
                 DIRS="/var/log/unit /var/run/unit /etc/unit /etc/ssl/private/ /var/lib/unit/ /var/www/"
@@ -96,13 +96,13 @@ case "$OS" in
                 DIRS="/var/www/ $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             fpm)
-                DIRS="/var/www/ /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
+                DIRS="/var/www/ /usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             apache)
-                DIRS="/etc/apache2 /etc/ssl/private /var/www/ /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
+                DIRS="/etc/apache2 /etc/ssl/private /var/www/ /usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             nginx)
-                DIRS="/etc/nginx/ /var/log/nginx /etc/ssl/private /var/lib/nginx /var/www/ /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
+                DIRS="/etc/nginx/ /var/log/nginx /etc/ssl/private /var/lib/nginx /var/www/ /usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             *)
                 echo "$script_name: Unsupported SERVICE: $SERVICE"


### PR DESCRIPTION
# Problem
- When `LOG_OUTPUT_LEVEL` was set to `debug`, it wasn't working with PHP FPM

# What this PR does
- It allows the `log_level` for PHP FPM to be set on the fly
- It also translates the standards from [Apache](https://httpd.apache.org/docs/2.4/mod/core.html#loglevel) and [NGINX](https://docs.nginx.com/nginx/admin-guide/monitoring/logging/) to what FPM expects as a log level