### PR TITLE
Update S6 and PHP extension installer versions

### DIFF
--- a/src/common/usr/local/bin/docker-php-serversideup-install-php-ext-installer
+++ b/src/common/usr/local/bin/docker-php-serversideup-install-php-ext-installer
@@ -11,7 +11,7 @@ script_name="docker-php-serversideup-install-php-ext-installer"
 ############
 # Environment variables
 ############
-PHP_EXT_INSTALLER_VERSION="2.2.14"
+PHP_EXT_INSTALLER_VERSION="2.2.16"
 
 ############
 # Main

--- a/src/s6/usr/local/bin/docker-php-serversideup-s6-install
+++ b/src/s6/usr/local/bin/docker-php-serversideup-s6-install
@@ -9,7 +9,7 @@ set -oue
 # Be sure to set the S6_SRC_URL, S6_SRC_DEP, and S6_DIR
 # environment variables before running this script.
 
-S6_VERSION=v3.1.6.2
+S6_VERSION=v3.2.0.0
 mkdir -p $S6_DIR
 export SYS_ARCH=$(uname -m)
 case "$SYS_ARCH" in


### PR DESCRIPTION
## What this PR does

This PR bumps the versions of dependencies to:

- S6 Overlay: v3.2.0.0
- install-php-extensions: v2.2.16