### PR TITLE
changed case of `as` to `AS` to stay inline with convention

### DIFF
--- a/docs/content/docs/3.guide/100.migrating-from-v2-to-v3.md
+++ b/docs/content/docs/3.guide/100.migrating-from-v2-to-v3.md
@@ -131,7 +131,7 @@ label: Dockerfile
 
 # Learn more about the Server Side Up PHP Docker Images at:
 # https://serversideup.net/open-source/docker-php/
-FROM serversideup/php:8.3-fpm-nginx as base
+FROM serversideup/php:8.3-fpm-nginx AS base
 
 ## Uncomment if you need to install additional PHP extensions
 # USER root
@@ -140,7 +140,7 @@ FROM serversideup/php:8.3-fpm-nginx as base
 ############################################
 # Development Image
 ############################################
-FROM base as development
+FROM base AS development
 
 # We can pass USER_ID and GROUP_ID as build arguments
 # to ensure the www-data user has the same UID and GID
@@ -157,7 +157,7 @@ USER www-data
 ############################################
 # CI image
 ############################################
-FROM base as ci
+FROM base AS ci
 
 # Sometimes CI images need to run as root
 # so we set the ROOT user and configure
@@ -169,7 +169,7 @@ RUN echo "user = www-data" >> /usr/local/etc/php-fpm.d/docker-php-serversideup-p
 ############################################
 # Production Image
 ############################################
-FROM base as deploy
+FROM base AS deploy
 COPY --chown=www-data:www-data . /var/www/html
 USER www-data
 ```

--- a/docs/content/docs/3.guide/2.understanding-file-permissions.md
+++ b/docs/content/docs/3.guide/2.understanding-file-permissions.md
@@ -43,12 +43,12 @@ label: Dockerfile
 ############################################
 # Base Image
 ############################################
-FROM serversideup/php:8.3-fpm-nginx-bookworm as base
+FROM serversideup/php:8.3-fpm-nginx-bookworm AS base
 
 ############################################
 # Development Image
 ############################################
-FROM base as development
+FROM base AS development
 
 # Switch to root so we can do root things
 USER root
@@ -74,7 +74,7 @@ USER www-data
 
 # Since we're calling "base", production isn't
 # calling any of that permission stuff
-FROM base as production
+FROM base AS production
 
 # Copy our app files as www-data (33:33)
 COPY --chown=www-data:www-data . /var/www/html

--- a/docs/content/docs/5.customizing-the-image/2.installing-additional-php-extensions.md
+++ b/docs/content/docs/5.customizing-the-image/2.installing-additional-php-extensions.md
@@ -137,7 +137,7 @@ label: Dockerfile
 
 # Learn more about the Server Side Up PHP Docker Images at:
 # https://serversideup.net/open-source/docker-php/
-FROM serversideup/php:8.3-fpm-nginx as base
+FROM serversideup/php:8.3-fpm-nginx AS base
 
 # Switch to root before installing our PHP extensions
 USER root
@@ -146,7 +146,7 @@ RUN install-php-extensions bcmath gd
 ############################################
 # Development Image
 ############################################
-FROM base as development
+FROM base AS development
 
 # We can pass USER_ID and GROUP_ID as build arguments
 # to ensure the www-data user has the same UID and GID
@@ -165,7 +165,7 @@ USER www-data
 ############################################
 # CI image
 ############################################
-FROM base as ci
+FROM base AS ci
 
 # Sometimes CI images need to run as root
 # so we set the ROOT user and configure
@@ -177,7 +177,7 @@ RUN echo "user = www-data" >> /usr/local/etc/php-fpm.d/docker-php-serversideup-p
 ############################################
 # Production Image
 ############################################
-FROM base as deploy
+FROM base AS deploy
 COPY --chown=www-data:www-data . /var/www/html
 USER www-data
 ```

--- a/src/variations/fpm-apache/Dockerfile
+++ b/src/variations/fpm-apache/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_IMAGE="php:${PHP_VERSION}-fpm-${BASE_OS_VERSION}"
 ##########
 # S6 Build
 ##########
-FROM ${BASE_IMAGE} as s6-build
+FROM ${BASE_IMAGE} AS s6-build
 
 ARG S6_DIR='/opt/s6/'
 ARG S6_SRC_URL="https://github.com/just-containers/s6-overlay/releases/download"

--- a/src/variations/fpm-nginx/Dockerfile
+++ b/src/variations/fpm-nginx/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_IMAGE="php:${PHP_VERSION}-fpm-${BASE_OS_VERSION}"
 ##########
 # S6 Build
 ##########
-FROM ${BASE_IMAGE} as s6-build
+FROM ${BASE_IMAGE} AS s6-build
 
 ARG S6_DIR='/opt/s6/'
 ARG S6_SRC_URL="https://github.com/just-containers/s6-overlay/releases/download"
@@ -20,7 +20,7 @@ RUN docker-php-serversideup-s6-install
 ####################
 # NGINX Signing Key
 ####################
-FROM php:${PHP_VERSION}-fpm as nginx-repo-config
+FROM php:${PHP_VERSION}-fpm AS nginx-repo-config
 
 ARG SIGNING_KEY_URL="https://nginx.org/keys/nginx_signing.key"
 ARG SIGNING_FINGERPRINT="573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62"

--- a/src/variations/unit/Dockerfile
+++ b/src/variations/unit/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_IMAGE="php:${PHP_VERSION}-cli-${BASE_OS_VERSION}"
 ##########
 # Unit Build
 ##########
-FROM ${BASE_IMAGE} as build
+FROM ${BASE_IMAGE} AS build
 ARG DEPENDENCY_PACKAGES_ALPINE='build-base curl tar mercurial openssl-dev pcre2-dev shadow'
 ARG DEPENDENCY_PACKAGES_DEBIAN='ca-certificates mercurial build-essential libssl-dev libpcre2-dev curl pkg-config'
 ARG NGINX_UNIT_VERSION='1.32.1-1'


### PR DESCRIPTION
https://docs.docker.com/reference/dockerfile/#format

`However, convention is for them to be UPPERCASE to distinguish them from arguments more easily.`