### PR TITLE
fix docs regarding `AUTORUN_LARAVEL_MIGRATION_ISOLATION`

### DIFF
--- a/docs/content/docs/2.getting-started/3.default-configurations.md
+++ b/docs/content/docs/2.getting-started/3.default-configurations.md
@@ -105,7 +105,7 @@ We also provide a few default scripts to help you get started.
 | `1-debug-mode.sh` | Sets PHP to debug mode if `LOG_OUTPUT_LEVEL = "debug"` | all |
 | `10-init-unit.sh` | Processes Unit templates, configures SSL (if enabled), and prepares NGINX Unit for launch | unit |
 | `10-init-webserver-config.sh` | Processes web server configuration templates, configures SSL (if enabled), and prepares web server for launch | *-nginx <br/> *-apache |
-| `50-laravel-automations.sh` | If `AUTORUN_ENABLED` is set to true, and a Laravel installation is detected, the following commands will automatically execute on container start: <br/> - `php artisan config:cache` <br/> - `php artisan route:cache` <br/> - `php artisan view:cache` <br/> - `php artisan event:cache` <br/> - `php artisan migrate --force --isolated` | all |
+| `50-laravel-automations.sh` | If `AUTORUN_ENABLED` is set to true, and a Laravel installation is detected, the following commands will automatically execute on container start: <br/> - `php artisan config:cache` <br/> - `php artisan route:cache` <br/> - `php artisan view:cache` <br/> - `php artisan event:cache` <br/> - `php artisan migrate --force` | all |
 
 ## Disabling Default Entrypoint Scripts
 If you want full control to customize your image, all default entrypoint scripts can be disabled by setting `DISABLE_DEFAULT_CONFIG` to `true`.


### PR DESCRIPTION
The default for `AUTORUN_LARAVEL_MIGRATION_ISOLATION` seems to be `false`, see https://github.com/serversideup/docker-php/blob/9999c0967575f66d8dd55f37f025f98885efde9c/src/common/etc/entrypoint.d/50-laravel-automations.sh#L73