### PR TITLE
Remove redundant PHP values in PHP FPM conf (Fixes #395)

### DIFF
--- a/.github/workflows/service_docker-build-and-publish.yml
+++ b/.github/workflows/service_docker-build-and-publish.yml
@@ -64,7 +64,7 @@ jobs:
 
   docker-publish:
     needs: setup-matrix
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     strategy:
       matrix: ${{fromJson(needs.setup-matrix.outputs.php-version-map-json)}}
 

--- a/.github/workflows/service_docker-build-and-publish.yml
+++ b/.github/workflows/service_docker-build-and-publish.yml
@@ -64,7 +64,7 @@ jobs:
 
   docker-publish:
     needs: setup-matrix
-    runs-on: self-hosted
+    runs-on: ubuntu-22.04
     strategy:
       matrix: ${{fromJson(needs.setup-matrix.outputs.php-version-map-json)}}
 

--- a/src/php-fpm.d/usr/local/etc/php-fpm.d/docker-php-serversideup-pool.conf
+++ b/src/php-fpm.d/usr/local/etc/php-fpm.d/docker-php-serversideup-pool.conf
@@ -255,23 +255,3 @@ ping.path = /healthcheck
 ; response is formatted as text/plain with a 200 response code.
 ; Default Value: pong
 ping.response = OK
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Common PHP Settings (controlled by environment variables)
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-; Regional settings
-php_value[date.timezone] = ${PHP_DATE_TIMEZONE}
-
-; Error reporting settings
-php_value[display_errors] = ${PHP_DISPLAY_ERRORS}
-php_value[display_startup_errors] = ${PHP_DISPLAY_STARTUP_ERRORS}
-php_value[error_reporting] = ${PHP_ERROR_REPORTING}
-
-; Performance settings
-php_value[memory_limit] = ${PHP_MEMORY_LIMIT}
-php_value[max_execution_time] = ${PHP_MAX_EXECUTION_TIME}
-
-; Upload settings
-php_value[post_max_size] = ${PHP_POST_MAX_SIZE}
-php_value[upload_max_filesize] = ${PHP_UPLOAD_MAX_FILE_SIZE}


### PR DESCRIPTION
# Problem
- In our `fpm*` variations, PHP ini settings were being set on the FPM configuration and the PHP ini
- The FPM configuration would override any INI settings, even if you set them yourself

## More Explanation in my video
Check this video out for more detail:

[![image](https://github.com/serversideup/docker-php/assets/3174134/7890cbb0-39cf-49f9-8f6c-118c859adb78)](https://twitter.com/jaydrogers/status/1811413958248599899)


# Solution
- [x] Remove the redundant FPM configurations setting the INI settings
- [x] Ensure any custom ini settings will always override any environment variable settings

