### PR TITLE
Add creating missing SQLite database files

### DIFF
--- a/src/common/etc/entrypoint.d/50-laravel-automations.sh
+++ b/src/common/etc/entrypoint.d/50-laravel-automations.sh
@@ -73,7 +73,7 @@ touch_sqlite_database() {
 
 # Set default values for Laravel automations
 : "${AUTORUN_ENABLED:=false}"
-: "${AUTORUN_LARAVEL_TOUCH_SQLITE:=false}"
+: "${AUTORUN_LARAVEL_TOUCH_SQLITE:=true}"
 : "${AUTORUN_LARAVEL_MIGRATION_TIMEOUT:=30}"
 
 if [ "$DISABLE_DEFAULT_CONFIG" = "false" ]; then

--- a/src/common/etc/entrypoint.d/50-laravel-automations.sh
+++ b/src/common/etc/entrypoint.d/50-laravel-automations.sh
@@ -45,15 +45,15 @@ touch_sqlite_database() {
 
         foreach (\$connections as \$name) {
             if (\$config->get(\"database.connections.\$name.driver\") !== 'sqlite') {
-                echo "Database \$name is not SQLite, skipping.";
+                echo \"Database [\$name] is not SQLite, skipping.\";
 
                 continue;
             }
 
-            \$fullpath = \$config->get("database.connections.\$name.database");
+            \$fullpath = \$config->get(\"database.connections.\$name.database\");
             
             if (\$files->exists(\$fullpath)) {
-                echo \"SQLite database \$fullpath already exists.\";
+                echo \"SQLite database [\$fullpath] already exists.\";
                 
                 continue;
             }
@@ -62,7 +62,7 @@ touch_sqlite_database() {
                 ->ensureDirectoryExists(pathinfo(\$fullpath, PATHINFO_DIRNAME))
                 ->put(\$fullpath, '');
 
-            echo \"✅ SQLite database \$fullpath created.\";
+            echo \"✅ SQLite database [\$fullpath] created.\";
         }
     "
 }

--- a/src/common/etc/entrypoint.d/50-laravel-automations.sh
+++ b/src/common/etc/entrypoint.d/50-laravel-automations.sh
@@ -64,7 +64,6 @@ touch_sqlite_database() {
 
             echo \"✅ SQLite database \$fullpath created.\";
         }
-}
     "
 }
 

--- a/src/common/etc/entrypoint.d/50-laravel-automations.sh
+++ b/src/common/etc/entrypoint.d/50-laravel-automations.sh
@@ -50,7 +50,7 @@ touch_sqlite_database() {
             if (\$config->get(\"database.connections.\$name.driver\") !== 'sqlite') {
                 echo \"Database [\$name] is not SQLite, skipping.\";
 
-                continue;
+                exit(1); // Database is not SQLite, exit with a status 1 (failure)
             }
 
             \$fullpath = \$config->get(\"database.connections.\$name.database\");

--- a/src/common/etc/entrypoint.d/50-laravel-automations.sh
+++ b/src/common/etc/entrypoint.d/50-laravel-automations.sh
@@ -44,7 +44,7 @@ touch_sqlite_database() {
 
         \$connections = in_array(['true', '1', 'default'], strtolower('$AUTORUN_LARAVEL_TOUCH_SQLITE'))
             ? [\$config->get('database.default')];
-            : array_map('rtrim', explode('$AUTORUN_LARAVEL_TOUCH_SQLITE', ','));
+            : array_map('trim', explode('$AUTORUN_LARAVEL_TOUCH_SQLITE', ','));
 
         foreach (\$connections as \$name) {
             if (\$config->get(\"database.connections.\$name.driver\") !== 'sqlite') {

--- a/src/common/etc/entrypoint.d/50-laravel-automations.sh
+++ b/src/common/etc/entrypoint.d/50-laravel-automations.sh
@@ -37,11 +37,14 @@ touch_sqlite_database() {
       require '$APP_BASE_DIR/vendor/autoload.php';
 
         \$app = require_once '$APP_BASE_DIR/bootstrap/app.php';
-        \$kernel = \$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
-
-        \$connections = array_map('rtrim', explode('$AUTORUN_LARAVEL_TOUCH_SQLITE', ','));
+        \$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+        
         \$config = \$app->make('config');
         \$files = \$app->make('files');
+
+        \$connections = in_array(['true', '1', 'default'], strtolower('$AUTORUN_LARAVEL_TOUCH_SQLITE'))
+            ? [\$config->get('database.default')];
+            : array_map('rtrim', explode('$AUTORUN_LARAVEL_TOUCH_SQLITE', ','));
 
         foreach (\$connections as \$name) {
             if (\$config->get(\"database.connections.\$name.driver\") !== 'sqlite') {

--- a/src/common/etc/entrypoint.d/50-laravel-automations.sh
+++ b/src/common/etc/entrypoint.d/50-laravel-automations.sh
@@ -73,6 +73,7 @@ touch_sqlite_database() {
 
 # Set default values for Laravel automations
 : "${AUTORUN_ENABLED:=false}"
+: "${AUTORUN_LARAVEL_TOUCH_SQLITE:=false}"
 : "${AUTORUN_LARAVEL_MIGRATION_TIMEOUT:=30}"
 
 if [ "$DISABLE_DEFAULT_CONFIG" = "false" ]; then
@@ -82,7 +83,7 @@ if [ "$DISABLE_DEFAULT_CONFIG" = "false" ]; then
         ############################################################################
         # touch sqlite databases
         ############################################################################
-        if [ ${AUTORUN_LARAVEL_TOUCH_SQLITE:+1} ]; then
+        if [ "${AUTORUN_LARAVEL_TOUCH_SQLITE:=true}" = "true" ]; then
             touch_sqlite_database() > /dev/null 2>&1
         fi;
 


### PR DESCRIPTION
This PR allows the container to start and create missing the SQLite databases set by the application.

It's part of the container `AUTORUN_LARAVEL` scripts. It runs before the migrations.

The way it works is through the `AUTORUN_LARAVEL_TOUCH_SQLITE` environment value, which by default is `true`:

- When `true`, `1` or `default`, it will pick the default connection.
- When used as `default, telescope, custom`, it will find the connection names, and create each database file.

This is done by checking if the driver is `sqlite` and the file doesn't exist. If it's not SQLite, it fails. If the database file already exists, doesn't do anything.