### PR TITLE
Adds storage directories recreation

### DIFF
--- a/src/common/etc/entrypoint.d/50-laravel-automations.sh
+++ b/src/common/etc/entrypoint.d/50-laravel-automations.sh
@@ -45,14 +45,14 @@ if [ "$DISABLE_DEFAULT_CONFIG" = "false" ]; then
         ############################################################################
         # recreate storage
         ############################################################################
-        if [ "${AUTORUN_LARAVEL_STORAGE:=true}" = "true" ]; then
+        if [ "${AUTORUN_LARAVEL_STORAGE_RECREATE:=true}" = "true" ]; then
 
-        storage_paths='storage storage/app/public storage/framework/cache/data storage/framework/sessions storage/framework/testings storage/framework/views storage/logs'
+        storage_paths='storage/app/public storage/framework/cache/data storage/framework/sessions storage/framework/testings storage/framework/views storage/logs'
 
         for path in ${storage_paths}; do
             if [ ! -d "$path" ]; then
                 mkdir -p "$path"
-                echo "✅ Rereated [$path] directory."
+                echo "✅ Recreated [$path] directory."
             fi
         done
         

--- a/src/common/etc/entrypoint.d/50-laravel-automations.sh
+++ b/src/common/etc/entrypoint.d/50-laravel-automations.sh
@@ -41,6 +41,21 @@ if [ "$DISABLE_DEFAULT_CONFIG" = "false" ]; then
     # Check to see if an Artisan file exists and assume it means Laravel is configured.
     if [ -f "$APP_BASE_DIR/artisan" ] && [ "$AUTORUN_ENABLED" = "true" ]; then
         echo "Checking for Laravel automations..."
+        
+        ############################################################################
+        # recreate storage
+        ############################################################################
+        if [ "${AUTORUN_LARAVEL_STORAGE:=true}" = "true" ]; then
+
+        storage_paths='storage storage/app/public storage/framework/cache/data storage/framework/sessions storage/framework/testings storage/framework/views storage/logs'
+
+        for path in ${storage_paths}; do
+            if [ ! -d "$path" ]; then
+                mkdir -p "$path"
+                echo "✅ Rereated [$path] directory."
+            fi
+        done
+        
         ############################################################################
         # artisan migrate
         ############################################################################


### PR DESCRIPTION
As title says. Sometimes you will mount the `/storage` path elsewhere for persistence. Laravel sometimes doesn't play nice if any of these are missing, like using `view:clear` which gives an error when the cache view directory doesn't exist.

The `AUTORUN_LARAVEL_STORAGE_RECREATE` environment variables re-creates the storage directories used by Laravel:

![image](https://github.com/user-attachments/assets/548c2dfc-aea7-462e-bb69-ea8dc70194e3)

It's opt-in.