### PR TITLE
Fixes #410 with subprocess

### DIFF
--- a/src/common/etc/entrypoint.d/0-container-info.sh
+++ b/src/common/etc/entrypoint.d/0-container-info.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-if [ "$SHOW_WELCOME_MESSAGE" = "false" ] || [ "$LOG_OUTPUT_LEVEL" = "off" ] || [ "$DISABLE_DEFAULT_CONFIG" = "true" ]; then
+if [ "$SHOW_WELCOME_MESSAGE" = "false" ] || [ "$DISABLE_DEFAULT_CONFIG" = "true" ]; then
     if [ "$LOG_OUTPUT_LEVEL" = "debug" ]; then
         echo "👉 $0: DISABLE_DEFAULT_CONFIG does not equal \"false\", so debug mode will NOT be automatically set."
     fi

--- a/src/common/usr/local/bin/docker-php-serversideup-entrypoint
+++ b/src/common/usr/local/bin/docker-php-serversideup-entrypoint
@@ -16,7 +16,7 @@ fi
 find /etc/entrypoint.d/ -type f -name '*.sh' | sort -n -t- -k1 | while IFS= read -r f; do
     [ -e "$f" ] || continue  # skip if not exists
     case "$f" in
-        *.sh)     . "$f" ;;
+        *.sh)     ( . "$f" ) ;;
         *)        echo "$0: Invalid extension. Ignoring $f" ;;
     esac
 done


### PR DESCRIPTION
This will fix #410 by invoking entrypoint scripts in a subshell to avoid exiting the main script when they call exit, which breaks the startup chain.

Scripts are sourced at the moment, but it should be safe (at least in the scope of the project itself) because default entrypoint scripts doesn't share anything. The only thing "shared" is the custom docker command, but this one uses the filesystem to do so (/tmp/docker_cmd_override) so it's safe.

BUT! It will definitely break for users if they have custom entrypoints that depends on each other. In this case it's safer to merge my alternative PR instead.
