### PR TITLE
Fixes #410 with returns

### DIFF
--- a/src/common/etc/entrypoint.d/0-container-info.sh
+++ b/src/common/etc/entrypoint.d/0-container-info.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-if [ "$SHOW_WELCOME_MESSAGE" = "false" ] || [ "$LOG_OUTPUT_LEVEL" = "off" ] || [ "$DISABLE_DEFAULT_CONFIG" = "true" ]; then
+if [ "$SHOW_WELCOME_MESSAGE" = "false" ] || [ "$DISABLE_DEFAULT_CONFIG" = "true" ]; then
     if [ "$LOG_OUTPUT_LEVEL" = "debug" ]; then
         echo "👉 $0: DISABLE_DEFAULT_CONFIG does not equal \"false\", so debug mode will NOT be automatically set."
     fi

--- a/src/common/etc/entrypoint.d/0-container-info.sh
+++ b/src/common/etc/entrypoint.d/0-container-info.sh
@@ -4,7 +4,7 @@ if [ "$SHOW_WELCOME_MESSAGE" = "false" ] || [ "$LOG_OUTPUT_LEVEL" = "off" ] || [
         echo "👉 $0: DISABLE_DEFAULT_CONFIG does not equal \"false\", so debug mode will NOT be automatically set."
     fi
     # Skip the rest of the script
-    exit 0
+    return 0
 fi
 
 echo '

--- a/src/common/etc/entrypoint.d/1-debug-mode.sh
+++ b/src/common/etc/entrypoint.d/1-debug-mode.sh
@@ -83,6 +83,6 @@ case "$LOG_OUTPUT_LEVEL" in
     ;;
     *)
     echo "👉 $script_name: LOG_OUTPUT_LEVEL is not set to a valid value. Please set it to one of the following: debug, info, notice, warn, error, crit, alert, emerg."
-    exit 1
+    return 1
     ;;
 esac

--- a/src/common/etc/entrypoint.d/50-laravel-automations.sh
+++ b/src/common/etc/entrypoint.d/50-laravel-automations.sh
@@ -66,7 +66,7 @@ if [ "$DISABLE_DEFAULT_CONFIG" = "false" ]; then
 
             if [ $count -eq "$timeout" ]; then
                 echo "Database connection failed after multiple attempts."
-                exit 1
+                return 1
             fi
 
             echo "🚀 Running migrations..."


### PR DESCRIPTION
Fixes #410, same idea of #427 of not breaking the initialization chain, but should be safer for the end user (since it doesn't break scripts relying on scripts being sourced in the same process)