### PR TITLE
Disable "x-powered-by" header

### DIFF
--- a/src/common/usr/local/etc/php/conf.d/serversideup-docker-php.ini
+++ b/src/common/usr/local/etc/php/conf.d/serversideup-docker-php.ini
@@ -397,7 +397,7 @@ zend.exception_string_param_max_len = 0
 ; threat in any way, but it makes it possible to determine whether you use PHP
 ; on your server or not.
 ; https://php.net/expose-php
-expose_php = On
+expose_php = Off
 
 ;;;;;;;;;;;;;;;;;;;
 ; Resource Limits ;


### PR DESCRIPTION
# What this PR does
- This removes the `x-powered-by` header, improving security so attackers don't know what PHP version you're running

### This will no longer display:
```
x-powered-by: PHP/8.3.11
```