### PR TITLE
Nginx Unit upgrade to 1.33.0 and other bug fixes

### DIFF
--- a/src/common/etc/entrypoint.d/0-container-info.sh
+++ b/src/common/etc/entrypoint.d/0-container-info.sh
@@ -4,7 +4,7 @@ if [ "$SHOW_WELCOME_MESSAGE" = "false" ] || [ "$LOG_OUTPUT_LEVEL" = "off" ] || [
         echo "👉 $0: Container info was display was skipped."
     fi
     # Skip the rest of the script
-    exit 0
+    return 0
 fi
 
 echo '

--- a/src/common/usr/local/bin/docker-php-serversideup-entrypoint
+++ b/src/common/usr/local/bin/docker-php-serversideup-entrypoint
@@ -40,11 +40,17 @@ export S6_INITIALIZED
 
 # Execute scripts from /etc/entrypoint.d/ in numeric order
 find /etc/entrypoint.d/ -type f -name '*.sh' | sort -n -t- -k1 | while IFS= read -r f; do
-    [ -e "$f" ] || continue  # skip if not exists
-    case "$f" in
-        *.sh)     . "$f" ;;
-        *)        echo "$0: Invalid extension. Ignoring $f" ;;
-    esac
+    if [ -e "$f" ]; then
+        if [ "$LOG_OUTPUT_LEVEL" = "debug" ]; then
+            echo "Executing $f"
+        fi
+        if ! . "$f"; then
+            echo "Error executing $f" >&2
+            exit 1
+        fi
+    else
+        echo "Warning: $f not found" >&2
+    fi
 done
 
 # first arg is `-f` or `--some-option`

--- a/src/variations/unit/Dockerfile
+++ b/src/variations/unit/Dockerfile
@@ -7,9 +7,9 @@ ARG BASE_IMAGE="php:${PHP_VERSION}-cli-${BASE_OS_VERSION}"
 # Unit Build
 ##########
 FROM ${BASE_IMAGE} AS build
-ARG DEPENDENCY_PACKAGES_ALPINE='build-base curl tar mercurial openssl-dev pcre2-dev shadow'
-ARG DEPENDENCY_PACKAGES_DEBIAN='ca-certificates mercurial build-essential libssl-dev libpcre2-dev curl pkg-config'
-ARG NGINX_UNIT_VERSION='1.32.1-1'
+ARG DEPENDENCY_PACKAGES_ALPINE='build-base curl tar git openssl-dev pcre2-dev shadow'
+ARG DEPENDENCY_PACKAGES_DEBIAN='ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config'
+ARG NGINX_UNIT_VERSION='1.33.0-1'
 
 # copy our scripts
 COPY --chmod=755 src/common/ /
@@ -20,7 +20,7 @@ RUN set -ex && \
     docker-php-serversideup-dep-install-debian "${DEPENDENCY_PACKAGES_DEBIAN}"  && \
     mkdir -p /usr/lib/unit/modules /usr/lib/unit/debug-modules && \
     cd /usr/src/ && \
-    hg clone -u ${NGINX_UNIT_VERSION} https://hg.nginx.org/unit && \
+    git clone --depth 1 -b ${NGINX_UNIT_VERSION} https://github.com/nginx/unit && \
     cd unit && \
     NCPU="$(getconf _NPROCESSORS_ONLN)" && \
     DEB_HOST_MULTIARCH="$(dpkg-architecture -q DEB_HOST_MULTIARCH)" && \

--- a/src/variations/unit/etc/entrypoint.d/10-init-unit.sh
+++ b/src/variations/unit/etc/entrypoint.d/10-init-unit.sh
@@ -129,9 +129,6 @@ configure_unit() {
         echo "$script_name: Ignoring $f";
     done
 
-    echo "$script_name: Setting access log to STDOUT..."
-    curl_put "-d" '"/dev/stdout"' "config/access_log"
-
     echo "$script_name: Stopping Unit daemon after initial configuration..."
     kill -TERM "$(/bin/cat /var/run/unit/unit.pid)"
 


### PR DESCRIPTION
# What this PR does
- Upgrades NGINX Unit to v1.33.0
- Improved Entrypoint execution (Fixes #410)
- Removed health check from access log (Fixes #448)