### PR TITLE
chore: fix typo in docs for new healthcheck script

### DIFF
--- a/docs/content/docs/3.guide/3.using-healthchecks-with-laravel.md
+++ b/docs/content/docs/3.guide/3.using-healthchecks-with-laravel.md
@@ -87,7 +87,7 @@ label: Using Healthcheck with Laravel Scheduler
 ---
 ```yaml
 healthcheck:
-  test: ["CMD", "healthcheck-scheduler"]
+  test: ["CMD", "healthcheck-schedule"]
 ```
 ::
 

--- a/docs/content/docs/4.laravel/2.laravel-task-scheduler.md
+++ b/docs/content/docs/4.laravel/2.laravel-task-scheduler.md
@@ -40,7 +40,7 @@ services:
     stop_signal: SIGTERM # Set this for graceful shutdown if you're using fpm-apache or fpm-nginx
     healthcheck:
       # This is our native healthcheck script for the scheduler
-      test: ["CMD", "healthcheck-scheduler"]
+      test: ["CMD", "healthcheck-schedule"]
       start_period: 10s
 ```
 ::


### PR DESCRIPTION
## Overview

Quick PR to address an inconsistency in the docs vs what is in the container.

The docs specify the health check for the scheduler as `["CMD", "healthcheck-scheduler"]`, but the actual file name is `healthcheck-schedule`.