### PR TITLE
Unit: Restrict access to hidden files and have PHP process files directly

### DIFF
--- a/src/variations/unit/etc/unit/config.d/ssl-full.json.template
+++ b/src/variations/unit/etc/unit/config.d/ssl-full.json.template
@@ -99,12 +99,38 @@
             },
             {
                 "match": {
+                    "uri": [
+                        "/.*",
+                        "/.*/",
+                        "/.*/*",
+                        "/*/.*",
+                        "/*/.*/",
+                        "/*/.*/*"
+                    ]
+                },
+                "action": {
+                    "return": 404
+                }
+            },
+            {
+                "match": {
+                    "uri": [
+                        "/*.php",
+                        "/*/*.php"
+                    ]
+                },
+                "action": {
+                    "pass": "applications/php/direct"
+                }
+            },
+            {
+                "match": {
                     "uri": "!/index.php"
                 },
                 "action": {
                     "share": "${UNIT_WEBROOT}$uri",
                     "fallback": {
-                        "pass": "applications/php"
+                        "pass": "applications/php/index"
                     }
                 }
             }
@@ -118,12 +144,19 @@
     "applications": {
         "php": {
             "type": "php",
-            "root": "${UNIT_WEBROOT}/",
-            "script": "index.php",
             "processes": {
                 "max": ${UNIT_PROCESSES_MAX},
                 "spare": ${UNIT_PROCESSES_SPARE},
                 "idle_timeout": ${UNIT_PROCESSES_IDLE_TIMEOUT}
+            }
+            "targets": {
+                "direct": {
+                    "root": "${UNIT_WEBROOT}/"
+                },
+                "index": {
+                    "root": "${UNIT_WEBROOT}/",
+                    "script": "index.php"
+                }
             }
         }
     },

--- a/src/variations/unit/etc/unit/config.d/ssl-full.json.template
+++ b/src/variations/unit/etc/unit/config.d/ssl-full.json.template
@@ -148,7 +148,7 @@
                 "max": ${UNIT_PROCESSES_MAX},
                 "spare": ${UNIT_PROCESSES_SPARE},
                 "idle_timeout": ${UNIT_PROCESSES_IDLE_TIMEOUT}
-            }
+            },
             "targets": {
                 "direct": {
                     "root": "${UNIT_WEBROOT}/"

--- a/src/variations/unit/etc/unit/config.d/ssl-mixed.json.template
+++ b/src/variations/unit/etc/unit/config.d/ssl-mixed.json.template
@@ -128,7 +128,7 @@
                 "max": ${UNIT_PROCESSES_MAX},
                 "spare": ${UNIT_PROCESSES_SPARE},
                 "idle_timeout": ${UNIT_PROCESSES_IDLE_TIMEOUT}
-            }
+            },
             "targets": {
                 "direct": {
                     "root": "${UNIT_WEBROOT}/"

--- a/src/variations/unit/etc/unit/config.d/ssl-mixed.json.template
+++ b/src/variations/unit/etc/unit/config.d/ssl-mixed.json.template
@@ -80,12 +80,38 @@
         },
         {
             "match": {
+                "uri": [
+                    "/.*",
+                    "/.*/",
+                    "/.*/*",
+                    "/*/.*",
+                    "/*/.*/",
+                    "/*/.*/*"
+                ]
+            },
+            "action": {
+                "return": 404
+            }
+        },
+        {
+            "match": {
+                "uri": [
+                    "/*.php",
+                    "/*/*.php"
+                ]
+            },
+            "action": {
+                "pass": "applications/php/direct"
+            }
+        },
+        {
+            "match": {
                 "uri": "!/index.php"
             },
             "action": {
                 "share": "${UNIT_WEBROOT}$uri",
                 "fallback": {
-                    "pass": "applications/php"
+                    "pass": "applications/php/index"
                 }
             }
         }
@@ -98,12 +124,19 @@
     "applications": {
         "php": {
             "type": "php",
-            "root": "${UNIT_WEBROOT}/",
-            "script": "index.php",
             "processes": {
                 "max": ${UNIT_PROCESSES_MAX},
                 "spare": ${UNIT_PROCESSES_SPARE},
                 "idle_timeout": ${UNIT_PROCESSES_IDLE_TIMEOUT}
+            }
+            "targets": {
+                "direct": {
+                    "root": "${UNIT_WEBROOT}/"
+                },
+                "index": {
+                    "root": "${UNIT_WEBROOT}/",
+                    "script": "index.php"
+                }
             }
         }
     },

--- a/src/variations/unit/etc/unit/config.d/ssl-off.json.template
+++ b/src/variations/unit/etc/unit/config.d/ssl-off.json.template
@@ -91,7 +91,7 @@
                 "max": ${UNIT_PROCESSES_MAX},
                 "spare": ${UNIT_PROCESSES_SPARE},
                 "idle_timeout": ${UNIT_PROCESSES_IDLE_TIMEOUT}
-            }
+            },
             "targets": {
                 "direct": {
                     "root": "${UNIT_WEBROOT}/"

--- a/src/variations/unit/etc/unit/config.d/ssl-off.json.template
+++ b/src/variations/unit/etc/unit/config.d/ssl-off.json.template
@@ -43,12 +43,38 @@
         },
         {
             "match": {
+                "uri": [
+                    "/.*",
+                    "/.*/",
+                    "/.*/*",
+                    "/*/.*",
+                    "/*/.*/",
+                    "/*/.*/*"
+                ]
+            },
+            "action": {
+                "return": 404
+            }
+        },
+        {
+            "match": {
+                "uri": [
+                    "/*.php",
+                    "/*/*.php"
+                ]
+            },
+            "action": {
+                "pass": "applications/php/direct"
+            }
+        },
+        {
+            "match": {
                 "uri": "!/index.php"
             },
             "action": {
                 "share": "${UNIT_WEBROOT}$uri",
                 "fallback": {
-                    "pass": "applications/php"
+                    "pass": "applications/php/index"
                 }
             }
         }
@@ -61,12 +87,19 @@
     "applications": {
         "php": {
             "type": "php",
-            "root": "${UNIT_WEBROOT}/",
-            "script": "index.php",
             "processes": {
                 "max": ${UNIT_PROCESSES_MAX},
                 "spare": ${UNIT_PROCESSES_SPARE},
                 "idle_timeout": ${UNIT_PROCESSES_IDLE_TIMEOUT}
+            }
+            "targets": {
+                "direct": {
+                    "root": "${UNIT_WEBROOT}/"
+                },
+                "index": {
+                    "root": "${UNIT_WEBROOT}/",
+                    "script": "index.php"
+                }
             }
         }
     },


### PR DESCRIPTION
Updating the routing in the Unit configuration to accomplish a couple of things:

The following routes step restricts access to hidden files and folders (start with `.`)

```
{
    "match": {
        "uri": [
             "/.*",
            "/.*/",
            "/.*/*",
            "/*/.*",
            "/*/.*/",
            "/*/.*/*"
        ]
    },
    "action": {
        "return": 404
    }
},
```

The following section allows the processing of PHP files requested directly. See #11 for more details. The issue with PHP files being downloaded instead of processed was due to the `share` entry in the `action`. The `share` entry will download the file if there is a match and pass the URI to the application handler only if the file doesn't exist. Removing the `share` entry and moving the `pass` entry out of `fallback` allows the PHP file to be processed directly.

```
{
    "match": {
        "uri": [
            "/*.php",
            "/*/*.php"
        ]
    },
    "action": {
        "pass": "applications/php/direct"
    }
},
```

