### PR TITLE
Replace `exit` with `return` in entrypoint scripts

### DIFF
--- a/src/common/etc/entrypoint.d/1-debug-mode.sh
+++ b/src/common/etc/entrypoint.d/1-debug-mode.sh
@@ -5,7 +5,7 @@ if [ "$DISABLE_DEFAULT_CONFIG" = true ]; then
     if [ "$LOG_OUTPUT_LEVEL" = "debug" ]; then
         echo "👉 $script_name: DISABLE_DEFAULT_CONFIG does not equal \"false\", so debug mode will NOT be automatically set."
     fi
-    exit 0 # Exit if DISABLE_DEFAULT_CONFIG is true
+    return 0 # Exit if DISABLE_DEFAULT_CONFIG is true
 fi
 
 #######################################
@@ -84,6 +84,6 @@ case "$LOG_OUTPUT_LEVEL" in
     ;;
     *)
     echo "👉 $script_name: LOG_OUTPUT_LEVEL is not set to a valid value. Please set it to one of the following: debug, info, notice, warn, error, crit, alert, emerg."
-    exit 1
+    return 1
     ;;
 esac

--- a/src/common/etc/entrypoint.d/50-laravel-automations.sh
+++ b/src/common/etc/entrypoint.d/50-laravel-automations.sh
@@ -66,7 +66,7 @@ if [ "$DISABLE_DEFAULT_CONFIG" = "false" ]; then
 
             if [ $count -eq "$timeout" ]; then
                 echo "Database connection failed after multiple attempts."
-                exit 1
+                return 1
             fi
 
             echo "🚀 Running migrations..."

--- a/src/s6/etc/entrypoint.d/10-init-webserver-config.sh
+++ b/src/s6/etc/entrypoint.d/10-init-webserver-config.sh
@@ -10,7 +10,7 @@ script_name="init-webserver-config"
 # Check if S6 is initialized
 if [ "$S6_INITIALIZED" != "true" ]; then
     echo "ℹ️  [NOTICE]: S6 is not initialized. Skipping web server configuration and running custom command."
-    exit 0
+    return 0
 fi
 
 ##########
@@ -172,7 +172,7 @@ if [ "$DISABLE_DEFAULT_CONFIG" = false ]; then
         enable_nginx_site "$SSL_MODE"
     else
         echo "🛑 ERROR ($script_name): Neither Apache nor NGINX could be detected."
-        exit 1
+        return 1
     fi
 else
     if [ "$LOG_OUTPUT_LEVEL" = "debug" ]; then


### PR DESCRIPTION
Calling `exit` in entrypoint scripts prevents subsequent scripts to run.

I noticed the issue withe the `v3.4` beta when running a custom command because `10-init-webserver-config.sh` calls `exit 0` and prevents `50-laravel-automations.sh` to run.
