### PR TITLE
Adding Cache-Control header to assets and media files

### DIFF
--- a/src/variations/fpm-nginx/etc/nginx/server-opts.d/performance.conf
+++ b/src/variations/fpm-nginx/etc/nginx/server-opts.d/performance.conf
@@ -12,7 +12,7 @@ location = /robots.txt {
 
 # assets, media
 location ~* \.(?:css(\.map)?|js(\.map)?|jpe?g|png|gif|ico|cur|heic|webp|tiff?|mp3|m4a|aac|ogg|midi?|wav|mp4|mov|webm|mpe?g|avi|ogv|flv|wmv)$ {
-    expires    7d;
+    add_header Cache-Control "public, max-age=31536000, immutable";
     access_log off;
     log_not_found off;
     # Pass to PHP to ensure PHP apps can handle routes that end in these filetypes
@@ -22,7 +22,7 @@ location ~* \.(?:css(\.map)?|js(\.map)?|jpe?g|png|gif|ico|cur|heic|webp|tiff?|mp
 # svg, fonts
 location ~* \.(?:svgz?|ttf|ttc|otf|eot|woff2?)$ {
     add_header Access-Control-Allow-Origin "*";
-    expires    7d;
+    add_header Cache-Control "public, max-age=31536000, immutable";
     access_log off;
 }
 


### PR DESCRIPTION
I added the `Cache-Control` header to assets and media files.

Most of applications use the cache-busting pattern so to increase performance we can cache assets basically forever and I added the `immutable` directive.

As explained in the Mozilla documentation:

> When a user reloads the browser, the browser will send conditional requests for validating to the origin server. But it's not necessary to revalidate those kinds of static resources even when a user reloads the browser, because they're never modified. immutable tells a cache that the response is immutable while it's [fresh](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#fresh_and_stale_based_on_age) and avoids those kinds of unnecessary conditional requests to the server.

For instance, GitHub or Linkedin are already using it in production.

See: 
- https://www.keycdn.com/blog/cache-control-immutable
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control