### PR TITLE
Fix exit on error during migrations, CI updates, and improve notices and messages

### DIFF
--- a/.github/workflows/action_publish-images-prs.yml
+++ b/.github/workflows/action_publish-images-prs.yml
@@ -2,6 +2,11 @@ name: Docker Publish (PR Images)
 
 on:
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to build (leave empty for manual branch build)'
+        required: false
+        type: string
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
@@ -12,11 +17,16 @@ on:
 
 jobs:
   build-dev-images:
-    if: ${{ github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/service_docker-build-and-publish.yml
     with:
-      registry-repositories: "docker.io/serversideup/php-dev" # Set to our development repository
-      tag-prefix: "${{ github.event.pull_request.number }}"
+      registry-repositories: "docker.io/serversideup/php-dev"
+      # Use PR number from input if provided, otherwise use the PR event number
+      tag-prefix: ${{ inputs.pr_number || github.event.pull_request.number }}
       release-type: testing
       authenticate_with_ghcr: false
+      push-to-registry: >-
+        ${{ 
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.type == 'Organization')
+        }}
     secrets: inherit

--- a/.github/workflows/scheduled-task_update-sponsors.yml
+++ b/.github/workflows/scheduled-task_update-sponsors.yml
@@ -5,7 +5,7 @@ on:
     - cron: 30 15 * * 0-6
 jobs:
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4

--- a/.github/workflows/service_docker-build-and-publish.yml
+++ b/.github/workflows/service_docker-build-and-publish.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   setup-matrix:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       php-version-map-json: ${{ steps.get-php-versions.outputs.php-version-map-json }}
     steps:
@@ -68,10 +68,12 @@ jobs:
 
   docker-publish:
     needs: setup-matrix
-    runs-on:
-      - runs-on
-      - runner=4cpu-linux-x64
-      - run-id=${{ github.run_id }}
+    runs-on: ubuntu-24.04
+    ## Use AWS runners
+    # runs-on:
+    #   - runs-on
+    #   - runner=4cpu-linux-x64
+    #   - run-id=${{ github.run_id }}
     strategy:
       matrix: ${{fromJson(needs.setup-matrix.outputs.php-version-map-json)}}
 

--- a/.github/workflows/service_docker-build-and-publish.yml
+++ b/.github/workflows/service_docker-build-and-publish.yml
@@ -27,6 +27,10 @@ on:
         type: string
         default: 'testing'
         description: 'The type of release to create. Options: testing, latest'
+      push-to-registry:
+        type: boolean
+        default: true
+        description: 'Whether to push the images to the registry.'
 
 jobs:
   setup-matrix:
@@ -162,6 +166,6 @@ jobs:
             linux/arm/v7
             linux/arm64/v8
           pull: true
-          push: true
+          push: ${{ inputs.push-to-registry }}
           tags: ${{ env.DOCKER_TAGS }}
           outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Supercharge your PHP experience with Docker images that are based off the official PHP images but are optimized to be run in production environments for Laravel and WordPress and more

--- a/.github/workflows/service_docker-build-and-publish.yml
+++ b/.github/workflows/service_docker-build-and-publish.yml
@@ -99,13 +99,14 @@ jobs:
       ##
       - name: Login to DockerHub
         uses: docker/login-action@v3
+        if: ${{ inputs.push-to-registry }}
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
-        if: ${{ inputs.authenticate_with_ghcr }}
+        if: ${{ inputs.push-to-registry && inputs.authenticate_with_ghcr }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -145,7 +146,7 @@ jobs:
             echo "REPOSITORY_BUILD_VERSION=git-${SHORT_SHA}-${{ github.run_id }}" >> $GITHUB_ENV
           fi
 
-      - name: Build and push
+      - name: Build images
         uses: docker/build-push-action@v6
         with:
           file: src/variations/${{ matrix.php_variation }}/Dockerfile
@@ -154,13 +155,11 @@ jobs:
           ## Run-on cache
           # cache-from: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
           # cache-to: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
-
           build-args: |
             BASE_OS_VERSION=${{ matrix.base_os }}
             PHP_VERSION=${{ matrix.patch_version }}
             PHP_VARIATION=${{ matrix.php_variation }}
             REPOSITORY_BUILD_VERSION=${{ env.REPOSITORY_BUILD_VERSION }}
-
           platforms: |
             linux/amd64
             linux/arm64/v8

--- a/.github/workflows/service_docker-build-and-publish.yml
+++ b/.github/workflows/service_docker-build-and-publish.yml
@@ -145,8 +145,12 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: src/variations/${{ matrix.php_variation }}/Dockerfile
-          cache-from: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
-          cache-to: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
+          cache-from: type=gha
+          cache-to: type=gha
+          ## Run-on cache
+          # cache-from: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
+          # cache-to: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
+
           build-args: |
             BASE_OS_VERSION=${{ matrix.base_os }}
             PHP_VERSION=${{ matrix.patch_version }}

--- a/.github/workflows/service_docker-build-and-publish.yml
+++ b/.github/workflows/service_docker-build-and-publish.yml
@@ -163,7 +163,6 @@ jobs:
 
           platforms: |
             linux/amd64
-            linux/arm/v7
             linux/arm64/v8
           pull: true
           push: ${{ inputs.push-to-registry }}

--- a/docs/content/docs/5.customizing-the-image/3.adding-your-own-start-up-scripts.md
+++ b/docs/content/docs/5.customizing-the-image/3.adding-your-own-start-up-scripts.md
@@ -18,6 +18,7 @@ Your script should:
 - Located in the `/etc/entrypoint.d` directory
 - Have the file extension ending in `.sh`
 ::
+
 We recommend writing your script in `/bin/sh` for the best compatibility between Alpine and Debian. If you choose to use `/bin/bash`, your script will only be able to run on Debian-based images.
 
 ## Choose your execution order
@@ -26,6 +27,15 @@ Since [we provide default entrypoint scripts](/docs/getting-started/default-conf
 ::note
 If you want to disable our entrypoint scripts, you can set `DISABLE_DEFAULT_CONFIG` to `true` in your environment variables.
 ::
+
+## Long running services
+::note
+Don't use entrypoint scripts for long-running services. You want your services to be monitored and restarted if they crash.
+::
+
+Anything in the `/etc/entrypoint.d` directory are scripts that are intended to run quickly and then move on. If you run a service as an entrypoint script, that service may crash and not be restarted.
+
+Instead, learn about [using S6 overlay](/docs/getting-started/using-s6-overlay) so your services can be properly initialized and monitored. See the [S6 Overylay project](https://github.com/just-containers/s6-overlay) for more details on how to write your own S6 service.
 
 ## Example: Create a custom entrypoint script
 In this example, let's create a `99-my-script.sh` so it executes after all the other default scripts.
@@ -94,6 +104,11 @@ services:
 ::
 
 In the above file, we're building our image using the `Dockerfile` in the current directory. We're also mounting our current directory to `/var/www/html` in the container.
+
+## Don't use `exit 0` in your script
+If you use `exit 0` in your script, it will stop the execution of the rest of the entrypoint scripts. We recommend using `return 0` instead. [See this discussion](https://github.com/serversideup/docker-php/issues/481#issuecomment-2463082306) for more details on why.
+
+Long story short, we don't use subshells to execute your scripts, so `exit 0` will not work as expected. We do this because we want to ensure your script has access to the environment variables that are set in the entrypoint scripts.
 
 ## Running our example
 When we run `docker compose up`, we should see the following output:

--- a/docs/content/docs/5.customizing-the-image/3.adding-your-own-start-up-scripts.md
+++ b/docs/content/docs/5.customizing-the-image/3.adding-your-own-start-up-scripts.md
@@ -35,7 +35,7 @@ Don't use entrypoint scripts for long-running services. You want your services t
 
 Anything in the `/etc/entrypoint.d` directory are scripts that are intended to run quickly and then move on. If you run a service as an entrypoint script, that service may crash and not be restarted.
 
-Instead, learn about [using S6 overlay](/docs/getting-started/using-s6-overlay) so your services can be properly initialized and monitored. See the [S6 Overylay project](https://github.com/just-containers/s6-overlay) for more details on how to write your own S6 service.
+Instead, learn about [using S6 overlay](/docs/guide/using-s6-overlay) so your services can be properly initialized and monitored. See the [S6 Overylay project](https://github.com/just-containers/s6-overlay) for more details on how to write your own S6 service.
 
 ## Example: Create a custom entrypoint script
 In this example, let's create a `99-my-script.sh` so it executes after all the other default scripts.

--- a/scripts/conf/php-versions-base-config.yml
+++ b/scripts/conf/php-versions-base-config.yml
@@ -11,7 +11,6 @@ php_versions:
     minor_versions:
       - minor: "8.0"
         base_os:
-          - name: alpine
           - name: bullseye
             default: true
         patch_versions:

--- a/scripts/conf/php-versions-base-config.yml
+++ b/scripts/conf/php-versions-base-config.yml
@@ -3,7 +3,6 @@ php_versions:
     minor_versions:
       - minor: "7.4"
         base_os:
-          - name: alpine
           - name: bullseye
             default: true
         patch_versions:

--- a/scripts/conf/php-versions-base-config.yml
+++ b/scripts/conf/php-versions-base-config.yml
@@ -3,6 +3,7 @@ php_versions:
     minor_versions:
       - minor: "7.4"
         base_os:
+          - name: alpine
           - name: bullseye
             default: true
         patch_versions:
@@ -11,6 +12,7 @@ php_versions:
     minor_versions:
       - minor: "8.0"
         base_os:
+          - name: alpine
           - name: bullseye
             default: true
         patch_versions:

--- a/src/common/etc/entrypoint.d/0-container-info.sh
+++ b/src/common/etc/entrypoint.d/0-container-info.sh
@@ -40,6 +40,8 @@ Docker user:   $(whoami)
 Docker uid:    $(id -u)
 Docker gid:    $(id -g)
 OPcache:       $PHP_OPCACHE_MESSAGE
+PHP Version:   $(php -r 'echo phpversion();')
+Image Version: $(cat /etc/serversideup-php-version)
 "
 
 if [ "$PHP_OPCACHE_STATUS" = "0" ]; then

--- a/src/common/etc/entrypoint.d/50-laravel-automations.sh
+++ b/src/common/etc/entrypoint.d/50-laravel-automations.sh
@@ -51,6 +51,9 @@ if [ "$DISABLE_DEFAULT_CONFIG" = "false" ]; then
             echo "🚀 Clearing Laravel cache before attempting migrations..."
             php "$APP_BASE_DIR/artisan" config:clear
 
+            # Do not exit on error for this loop
+            set +e
+            echo "⚡️ Attempting database connection..."
             while [ $count -lt "$timeout" ]; do
                 test_db_connection > /dev/null 2>&1
                 status=$?
@@ -63,6 +66,9 @@ if [ "$DISABLE_DEFAULT_CONFIG" = "false" ]; then
                     sleep 1
                 fi
             done
+
+            # Re-enable exit on error
+            set -e
 
             if [ $count -eq "$timeout" ]; then
                 echo "Database connection failed after multiple attempts."

--- a/src/s6/etc/entrypoint.d/10-init-webserver-config.sh
+++ b/src/s6/etc/entrypoint.d/10-init-webserver-config.sh
@@ -9,7 +9,7 @@ script_name="init-webserver-config"
 
 # Check if S6 is initialized
 if [ "$S6_INITIALIZED" != "true" ]; then
-    echo "ℹ️  [NOTICE]: S6 is not initialized. Skipping web server configuration and running custom command."
+    echo "ℹ️  [NOTICE]: Running custom command instead of web server configuration: '$*'"
     return 0
 fi
 

--- a/src/variations/cli/Dockerfile
+++ b/src/variations/cli/Dockerfile
@@ -59,6 +59,9 @@ RUN docker-php-serversideup-dep-install-alpine "${DEPENDENCY_PACKAGES_ALPINE}" &
     chown -R www-data:www-data /var/www && \
     chmod -R 755 /var/www && \
     \
+    # Set the image version
+    echo "${REPOSITORY_BUILD_VERSION}" > /etc/serversideup-php-version && \
+    \
     # Make composer cache directory
     mkdir -p "${COMPOSER_HOME}" && \
     chown -R www-data:www-data "${COMPOSER_HOME}" && \

--- a/src/variations/fpm-apache/Dockerfile
+++ b/src/variations/fpm-apache/Dockerfile
@@ -104,6 +104,9 @@ RUN docker-php-serversideup-dep-install-debian "${DEPENDENCY_PACKAGES_DEBIAN}"  
     chown -R www-data:www-data /var/www && \
     chmod -R 755 /var/www && \
     \
+    # Set the image version
+    echo "${REPOSITORY_BUILD_VERSION}" > /etc/serversideup-php-version && \
+    \
     # Make composer cache directory
     mkdir -p "${COMPOSER_HOME}" && \
     chown -R www-data:www-data "${COMPOSER_HOME}" && \

--- a/src/variations/fpm-nginx/Dockerfile
+++ b/src/variations/fpm-nginx/Dockerfile
@@ -134,6 +134,9 @@ RUN docker-php-serversideup-dep-install-alpine "${DEPENDENCY_PACKAGES_ALPINE}" &
     chown -R www-data:www-data /var/www && \
     chmod -R 755 /var/www && \
     \
+    # Set the image version
+    echo "${REPOSITORY_BUILD_VERSION}" > /etc/serversideup-php-version && \
+    \
     # Make composer cache directory
     mkdir -p "${COMPOSER_HOME}" && \
     chown -R www-data:www-data "${COMPOSER_HOME}" && \

--- a/src/variations/fpm/Dockerfile
+++ b/src/variations/fpm/Dockerfile
@@ -67,6 +67,9 @@ RUN rm -rf /usr/local/etc/php-fpm.d/*.conf && \
     chown -R www-data:www-data /var/www && \
     chmod -R 755 /var/www && \
     \
+    # Set the image version
+    echo "${REPOSITORY_BUILD_VERSION}" > /etc/serversideup-php-version && \
+    \
     # Make composer cache directory
     mkdir -p "${COMPOSER_HOME}" && \
     chown -R www-data:www-data "${COMPOSER_HOME}" && \


### PR DESCRIPTION
# What this PR does
This PR does the following:

## ⚠️ Deprecation warning
- We removed `linux/arm/v7` because it's old and it was adding to our build times. These are 32-bit Arm processors. We still support 64-bit ARM (like M-series macs) with `linux/arm64/v8`

## 🐛 Bug Fixes
- #489 

## 🤩 Improvements
- Improved notices when running a custom command with S6 Overlay
- Added PHP version and Docker image tag version to container info at start up

## 🤓 Development improvements
- Added platform support to local build script
- We added a new method to improve PR experiences so we can streamline contributions
- Moved from Runs-on back to hosted GHA runners for cost reasons