### PR TITLE
Referrer policy fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # Ensure node files do not appear
+.idea
+vscode
 package-lock.json
 package.json
 yarn.lock

--- a/src/variations/fpm-apache/etc/apache2/conf-available/security.conf
+++ b/src/variations/fpm-apache/etc/apache2/conf-available/security.conf
@@ -84,15 +84,15 @@ Header always set X-Frame-Options: "sameorigin"
 #
 # Referrer policy
 #
-Header always set Referrer-Policy "no-referrer-when-downgrade"
+Header always set Referrer-Policy "strict-origin-when-cross-origin"
 
 #
 # Content Security Policy
 # UPDATE - September 2020: Commenting this out until we grasp better security requirements
-# 
+#
 #Header always set Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'"
 
 #
 # Strict-Transport-Security Policy (set HSTS)
 #
-Header always set Strict-Transport-Security "max-age=15552000; includeSubDomains"
+Header always set Strict-Transport-Security "max-age=15552000; includeSubDomains";


### PR DESCRIPTION
I am getting into the console this 

![image](https://github.com/user-attachments/assets/4e28a2a8-6951-4530-9e20-0029003e40e2)

to make it better recommends 

![image](https://github.com/user-attachments/assets/c35b1bf3-7520-4f26-b729-f442961613f2)

after adding 

`Header always set Referrer-Policy "strict-origin-when-cross-origin"`

all notices are gone.