### PR TITLE
Move SVG handling to media assets block for Symfony's Asset Mapper compatibility

### DIFF
--- a/src/variations/fpm-nginx/etc/nginx/server-opts.d/performance.conf
+++ b/src/variations/fpm-nginx/etc/nginx/server-opts.d/performance.conf
@@ -11,7 +11,7 @@ location = /robots.txt {
 }
 
 # assets, media
-location ~* \.(?:css(\.map)?|js(\.map)?|jpe?g|png|gif|ico|cur|heic|webp|tiff?|mp3|m4a|aac|ogg|midi?|wav|mp4|mov|webm|mpe?g|avi|ogv|flv|wmv)$ {
+location ~* \.(?:css(\.map)?|js(\.map)?|jpe?g|png|gif|ico|cur|heic|webp|tiff?|mp3|m4a|aac|ogg|midi?|wav|mp4|mov|webm|mpe?g|avi|ogv|flv|wmv|svgz?)$ {
     expires    7d;
     access_log off;
     log_not_found off;
@@ -19,8 +19,8 @@ location ~* \.(?:css(\.map)?|js(\.map)?|jpe?g|png|gif|ico|cur|heic|webp|tiff?|mp
     try_files $uri /index.php?$query_string; 
 }
 
-# svg, fonts
-location ~* \.(?:svgz?|ttf|ttc|otf|eot|woff2?)$ {
+# fonts
+location ~* \.(?:ttf|ttc|otf|eot|woff2?)$ {
     add_header Access-Control-Allow-Origin "*";
     expires    7d;
     access_log off;


### PR DESCRIPTION
# 👉 Describe the problem
The current Nginx configuration separates SVG files from other media assets. This creates an inconsistency with how Symfony's Asset Mapper component handles assets, particularly in development environments where SVG files should be served through PHP just like other media assets.

# 👥 Problem evidence & reach
This affects all developers using Symfony's Asset Mapper with this Nginx configuration. The inconsistent handling causes problems in development environments where Asset Mapper needs to serve versioned SVG files through PHP, but the Nginx configuration doesn't forward these requests correctly.

# 🏆 How to solve this problem
Move the SVG file handling from the "svg, fonts" location block to the "assets, media" location block to align with Asset Mapper's handling of assets in both development and production environments.


# 🥰 Describe the "impact" on users?
This change will provide seamless integration with Symfony's Asset Mapper component. In development, SVG files will be properly served through the PHP application, allowing for dynamic versioning. In production (after running `asset-map:compile`), they'll be served directly by Nginx with appropriate caching headers. Developers will have a more consistent experience across environments and won't encounter issues specific to SVG files.

# 💯 How do we validate the problem is solved?
* In development: Versioned SVG files (like `/assets/images/logo-3c16d92m.svg`) should be correctly handled by the PHP application
* In production: After running `asset-map:compile`, SVG files should be served directly from the filesystem with proper caching
* Confirm there are no 404 errors for SVG assets in either environment