### PR TITLE
Bump s6-overlay version to `v3.2.1.0`

### DIFF
--- a/src/s6/usr/local/bin/docker-php-serversideup-s6-install
+++ b/src/s6/usr/local/bin/docker-php-serversideup-s6-install
@@ -9,7 +9,7 @@ set -oue
 # Be sure to set the S6_SRC_URL, S6_SRC_DEP, and S6_DIR
 # environment variables before running this script.
 
-S6_VERSION=v3.2.0.2
+S6_VERSION=v3.2.1.0
 mkdir -p $S6_DIR
 export SYS_ARCH=$(uname -m)
 case "$SYS_ARCH" in


### PR DESCRIPTION
Last week [v3.2.1.0](https://github.com/just-containers/s6-overlay/releases/tag/v3.2.1.0) version of s6-overlay was released.

It resolves long standing issue/bug with permission (critical from my perspective) that is a big pain for kubernetes usage on images that use s6 (like docker-php), see https://github.com/just-containers/s6-overlay/issues/600 for details.

It would be cool if this PR could be pushed forward in some near future, thanks!