### PR TITLE
FEAT: add `NGINX_IPV6` env to toggle nginx IPv6 listening

### DIFF
--- a/src/s6/etc/entrypoint.d/10-init-webserver-config.sh
+++ b/src/s6/etc/entrypoint.d/10-init-webserver-config.sh
@@ -55,6 +55,12 @@ process_template() {
     echo "($script_name): Processing $template_file → $output_file..."
     envsubst "$subst_vars" < "$template_file" > "$output_file"
 
+    #Remove line containing listen [::]: to disable IPv6 listening
+    if [ "$NGINX_IPV6" == "false" ]; then
+        sed -i '/listen \[::\]:/d' "$output_file"
+        echo "ℹ️ NOTICE (init-webserver-config): disabling IPv6 for configuration $output_file..."
+    fi
+
     if [ "$LOG_OUTPUT_LEVEL" = "debug" ]; then
         echo "$script_name: Contents of $output_file:"
         cat $output_file


### PR DESCRIPTION
Hello,

I've been running into some problem with the default configuration listening to IPv6. I was hoping with this env, it enables user to toggle whether they want to listen on IPv6 address or not

![image](https://github.com/user-attachments/assets/532bd511-36b9-4cd5-b4a4-a75649f9b74e)

adding NGINX_IPV6=false environment will delete line containing `listen [::]:` on both `/etc/nginx/site-opts.d/http.conf` and `/etc/nginx/site-opts.d/https.conf`

I've tested this entrypoint script changes specifically in `8.2-fpm-nginx` but adding few lines like this should work in most nginx variation

Thank you