### PR TITLE
Update GitHub Actions workflow to use depot-ubuntu runners

### DIFF
--- a/.github/workflows/service_docker-build-and-publish.yml
+++ b/.github/workflows/service_docker-build-and-publish.yml
@@ -38,7 +38,7 @@ on:
 
 jobs:
   setup-matrix:
-    runs-on: ubuntu-24.04
+    runs-on: depot-ubuntu-24.04
     outputs:
       php-version-map-json: ${{ steps.get-php-versions.outputs.php-version-map-json }}
     steps:
@@ -78,12 +78,7 @@ jobs:
 
   docker-publish:
     needs: setup-matrix
-    runs-on: ubuntu-24.04
-    ## Use AWS runners
-    # runs-on:
-    #   - runs-on
-    #   - runner=4cpu-linux-x64
-    #   - run-id=${{ github.run_id }}
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix: ${{fromJson(needs.setup-matrix.outputs.php-version-map-json)}}
 
@@ -167,9 +162,6 @@ jobs:
           file: src/variations/${{ matrix.php_variation }}/Dockerfile
           cache-from: type=gha
           cache-to: type=gha
-          ## Run-on cache
-          # cache-from: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
-          # cache-to: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
           build-args: |
             BASE_OS_VERSION=${{ matrix.base_os }}
             PHP_VERSION=${{ matrix.patch_version }}

--- a/scripts/assemble-docker-tags.sh
+++ b/scripts/assemble-docker-tags.sh
@@ -253,6 +253,10 @@ echo "Latest Patch Version within Build Minor: $latest_patch_within_build_minor"
 echo "Default Base OS within Build Minor: $default_base_os_within_build_minor"
 echo "Latest Global Patch Version: $latest_patch_global"
 
+echo_color_message yellow "🔍 To replicate this build, run the following command:"
+echo "bash scripts/dev.sh --variation $build_variation --version $build_patch_version --os $build_base_os"
+echo
+
 # Set default tag
 DOCKER_TAGS=""
 add_docker_tag "$build_patch_version-$build_variation-$build_base_os"


### PR DESCRIPTION
- Changed the runner from ubuntu-24.04 to depot-ubuntu-24.04 for the setup-matrix job.
- Updated the docker-publish job to use depot-ubuntu-24.04-4 as the runner.
- Removed commented-out cache configuration for S3.