### PR TITLE
Trixie support, NGINX improvements, and CI improvements

### DIFF
--- a/.github/workflows/service_docker-build-and-publish.yml
+++ b/.github/workflows/service_docker-build-and-publish.yml
@@ -78,7 +78,7 @@ jobs:
 
   docker-publish:
     needs: setup-matrix
-    runs-on: ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix: ${{fromJson(needs.setup-matrix.outputs.php-version-map-json)}}
 

--- a/.github/workflows/service_docker-build-and-publish.yml
+++ b/.github/workflows/service_docker-build-and-publish.yml
@@ -38,7 +38,7 @@ on:
 
 jobs:
   setup-matrix:
-    runs-on: ubuntu-24.04
+    runs-on: depot-ubuntu-24.04
     outputs:
       php-version-map-json: ${{ steps.get-php-versions.outputs.php-version-map-json }}
     steps:

--- a/.github/workflows/service_docker-build-and-publish.yml
+++ b/.github/workflows/service_docker-build-and-publish.yml
@@ -79,11 +79,6 @@ jobs:
   docker-publish:
     needs: setup-matrix
     runs-on: ubuntu-24.04
-    ## Use AWS runners
-    # runs-on:
-    #   - runs-on
-    #   - runner=4cpu-linux-x64
-    #   - run-id=${{ github.run_id }}
     strategy:
       matrix: ${{fromJson(needs.setup-matrix.outputs.php-version-map-json)}}
 
@@ -161,20 +156,33 @@ jobs:
             echo "REPOSITORY_BUILD_VERSION=git-${SHORT_SHA}-${{ github.run_id }}" >> $GITHUB_ENV
           fi
 
+      - name: Compute NGINX build-arg (only for fpm-nginx)
+        id: compute_nginx
+        if: ${{ matrix.php_variation == 'fpm-nginx' }}
+        run: |
+          if command -v yq >/dev/null 2>&1; then
+            VERSION=$(yq -r '.operating_systems[].versions[] | select(.version == "${{ matrix.base_os }}") | .nginx_version' '${{ inputs.php-versions-file }}' | head -n1)
+          else
+            VERSION=$(awk -v key="${{ matrix.base_os }}" 'BEGIN{found=0} $1=="version:" && $2==key {found=1} found && $1=="nginx_version:" {print $2; exit}' "${{ inputs.php-versions-file }}")
+          fi
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "Unable to determine NGINX version for OS ${{ matrix.base_os }}" 1>&2
+            exit 1
+          fi
+          echo "nginx_arg=NGINX_VERSION=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Build images
         uses: docker/build-push-action@v6
         with:
           file: src/variations/${{ matrix.php_variation }}/Dockerfile
           cache-from: type=gha
           cache-to: type=gha
-          ## Run-on cache
-          # cache-from: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
-          # cache-to: type=s3,blobs_prefix=cache/${{ github.repository }}/,manifests_prefix=cache/${{ github.repository }}/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
           build-args: |
             BASE_OS_VERSION=${{ matrix.base_os }}
             PHP_VERSION=${{ matrix.patch_version }}
             PHP_VARIATION=${{ matrix.php_variation }}
             REPOSITORY_BUILD_VERSION=${{ env.REPOSITORY_BUILD_VERSION }}
+            ${{ steps.compute_nginx.outputs.nginx_arg }}
           platforms: |
             linux/amd64
             linux/arm64/v8

--- a/.github/workflows/service_docker-build-and-publish.yml
+++ b/.github/workflows/service_docker-build-and-publish.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Assemble PHP versions into the matrix. 😎
       id: get-php-versions
       run: |
-        MATRIX_JSON=$(yq -o=json scripts/conf/php-versions.yml | jq -c '{include: [(.php_variations[] | {name, supported_os: (.supported_os // ["alpine", "bullseye", "bookworm"])} ) as $variation | .php_versions[] | .minor_versions[] | .patch_versions[] as $patch | .base_os[] as $os | select($variation.supported_os | if length == 0 then . else . | index($os.name) end) | {patch_version: $patch, base_os: $os.name, php_variation: $variation.name}]} | {include: (.include | sort_by(.patch_version | split(".") | map(tonumber) | . as $nums | ($nums[0]*10000 + $nums[1]*100 + $nums[2])) | reverse)}')
+        MATRIX_JSON=$(bash ./scripts/generate-matrix.sh '${{ inputs.php-versions-file }}')
         echo "php-version-map-json=${MATRIX_JSON}" >> $GITHUB_OUTPUT
         echo "${MATRIX_JSON}" | jq '.'
   

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ All of our software is free an open to the world. None of this can be brought to
 #### Special thanks
 We'd like to specifically thank a few folks for taking the time for being a sound board that deeply influenced the direction of this project.
 
-Please check out all of their work:
+Please check out their work:
 - [Chris Fidao](https://x.com/fideloper)
 - [Joel Clermont](https://x.com/jclermont)
 - [Patricio](https://x.com/PatricioOnCode)

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ All of our software is free an open to the world. None of this can be brought to
 We'd like to specifically thank a few folks for taking the time for being a sound board that deeply influenced the direction of this project.
 
 Please check out all of their work:
-- [Chris Fidao](https://twitter.com/fideloper)
+- [Chris Fidao](https://x.com/fideloper)
 - [Joel Clermont](https://x.com/jclermont)
-- [Patricio](https://twitter.com/PatricioOnCode)
+- [Patricio](https://x.com/PatricioOnCode)
 
 ## About Us
 We're [Dan](https://twitter.com/danpastori) and [Jay](https://twitter.com/jaydrogers) - a two person team with a passion for open source products. We created [Server Side Up](https://serversideup.net) to help share what we learn.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ All of our software is free an open to the world. None of this can be brought to
 #### Bronze Sponsors
 <!-- bronze -->No bronze sponsors yet. <a href="https://github.com/sponsors/serversideup">Become a sponsor →</a><!-- bronze -->
 
+#### Special Infrastructure Sponsors
+This project takes an incredible amount of computing power to build and maintain over 8,000 different docker image tags. We're extremely grateful for the following sponsors who help bring the power to ship more PHP.
+
+<a href="https://depot.dev/"><img src="https://serversideup.net/sponsors/depot.png" alt="Depot" width="250px"></a>&nbsp;&nbsp;<a href="https://hub.docker.com/u/serversideup"><img src="https://serversideup.net/sponsors/docker.png" alt="Docker" width="250px"></a>
+
 #### Individual Supporters
 <!-- supporters --><a href="https://github.com/GeekDougle"><img src="https://github.com/GeekDougle.png" width="40px" alt="GeekDougle" /></a>&nbsp;&nbsp;<a href="https://github.com/JQuilty"><img src="https://github.com/JQuilty.png" width="40px" alt="JQuilty" /></a>&nbsp;&nbsp;<a href="https://github.com/MaltMethodDev"><img src="https://github.com/MaltMethodDev.png" width="40px" alt="MaltMethodDev" /></a>&nbsp;&nbsp;<a href="https://github.com/bananabrann"><img src="https://github.com/bananabrann.png" width="40px" alt="bananabrann" /></a>&nbsp;&nbsp;<!-- supporters -->
 

--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ Please check out all of their work:
 - [Patricio](https://x.com/PatricioOnCode)
 
 ## About Us
-We're [Dan](https://twitter.com/danpastori) and [Jay](https://twitter.com/jaydrogers) - a two person team with a passion for open source products. We created [Server Side Up](https://serversideup.net) to help share what we learn.
+We're [Dan](https://x.com/danpastori) and [Jay](https://x.com/jaydrogers) - a two person team with a passion for open source products. We created [Server Side Up](https://serversideup.net) to help share what we learn.
 
 <div align="center">
 
 | <div align="center">Dan Pastori</div>                  | <div align="center">Jay Rogers</div>                                 |
 | ----------------------------- | ------------------------------------------ |
-| <div align="center"><a href="https://twitter.com/danpastori"><img src="https://serversideup.net/wp-content/uploads/2023/08/dan.jpg" title="Dan Pastori" width="150px"></a><br /><a href="https://twitter.com/danpastori"><img src="https://serversideup.net/wp-content/themes/serversideup/images/open-source/twitter.svg" title="Twitter" width="24px"></a><a href="https://github.com/danpastori"><img src="https://serversideup.net/wp-content/themes/serversideup/images/open-source/github.svg" title="GitHub" width="24px"></a></div>                        | <div align="center"><a href="https://twitter.com/jaydrogers"><img src="https://serversideup.net/wp-content/uploads/2023/08/jay.jpg" title="Jay Rogers" width="150px"></a><br /><a href="https://twitter.com/jaydrogers"><img src="https://serversideup.net/wp-content/themes/serversideup/images/open-source/twitter.svg" title="Twitter" width="24px"></a><a href="https://github.com/jaydrogers"><img src="https://serversideup.net/wp-content/themes/serversideup/images/open-source/github.svg" title="GitHub" width="24px"></a></div>                                       |
+| <div align="center"><a href="https://x.com/danpastori"><img src="https://serversideup.net/wp-content/uploads/2023/08/dan.jpg" title="Dan Pastori" width="150px"></a><br /><a href="https://x.com/danpastori"><img src="https://serversideup.net/wp-content/themes/serversideup/images/open-source/twitter.svg" title="Twitter" width="24px"></a><a href="https://github.com/danpastori"><img src="https://serversideup.net/wp-content/themes/serversideup/images/open-source/github.svg" title="GitHub" width="24px"></a></div>                        | <div align="center"><a href="https://x.com/jaydrogers"><img src="https://serversideup.net/wp-content/uploads/2023/08/jay.jpg" title="Jay Rogers" width="150px"></a><br /><a href="https://x.com/jaydrogers"><img src="https://serversideup.net/wp-content/themes/serversideup/images/open-source/twitter.svg" title="Twitter" width="24px"></a><a href="https://github.com/jaydrogers"><img src="https://serversideup.net/wp-content/themes/serversideup/images/open-source/github.svg" title="GitHub" width="24px"></a></div>                                       |
 
 </div>
 
@@ -121,7 +121,7 @@ We're [Dan](https://twitter.com/danpastori) and [Jay](https://twitter.com/jaydro
 * **🤵‍♂️ [Get Professional Help](https://serversideup.net/professional-support)** - Get video + screen-sharing support from the core contributors.
 * **💻 [GitHub](https://github.com/serversideup)** - Check out our other open source projects.
 * **📫 [Newsletter](https://serversideup.net/subscribe)** - Skip the algorithms and get quality content right to your inbox.
-* **🐥 [Twitter](https://twitter.com/serversideup)** - You can also follow [Dan](https://twitter.com/danpastori) and [Jay](https://twitter.com/jaydrogers).
+* **🐥 [Twitter](https://x.com/serversideup)** - You can also follow [Dan](https://x.com/danpastori) and [Jay](https://x.com/jaydrogers).
 * **❤️ [Sponsor Us](https://github.com/sponsors/serversideup)** - Please consider sponsoring us so we can create more helpful resources.
 
 ## Our products

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Experience the ***true difference*** of using these images vs the other options 
 
 </details>
 
+## Professionally Supported
+Are you looking for help on integreating Docker with your PHP application? We have multiple options to help your team out:
+
+- [Get Managed Hosting](https://serversideup.net/hire-us/): CI/CD design and engineering, managed hosting, guaranteed uptime, any host, any server.
+- [Get Professional Help](https://schedule.serversideup.net/team/serversideup/quick-chat-with-jay): Get video + screen-sharing help directly from the core contributors.
+- [Get a Full-Stack Development Team](https://serversideup.net/hire-us/): We can build your app from the ground up, or help you with your existing codebase.
+
 ## Usage
 This repository creates a number of Docker image variations, allowing you to choose exactly what you need.
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ We'd like to specifically thank a few folks for taking the time for being a soun
 
 Please check out all of their work:
 - [Chris Fidao](https://twitter.com/fideloper)
-- [Joel Clermont](https://twitter.com/joelclermont)
+- [Joel Clermont](https://x.com/jclermont)
 - [Patricio](https://twitter.com/PatricioOnCode)
 
 ## About Us

--- a/docs/content/docs/2.getting-started/7.contributing.md
+++ b/docs/content/docs/2.getting-started/7.contributing.md
@@ -85,6 +85,31 @@ We use GitHub Actions exclusively to publish all of our releases. If the image e
 
 See `.github/workflows/action_publish-beta-images.yml` for an example of how we publish our beta images.
 
+## NGINX Versions
+We use the official NGINX repos to install the latest version of NGINX for each OS. The version to install is set by a build argument, which is loaded from the `scripts/conf/php-versions-base-config.yml` file.
+
+To view the current NGINX versions, run the following command:
+
+::code-panel
+---
+label: "View NGINX versions"
+---
+```bash
+./scripts/get-nginx-versions.sh
+```
+::
+
+This script will look at the official NGINX repos to find the latest version of NGINX for each OS. If you want to update the version, you can run the script with the `--write` flag.
+
+::code-panel
+---
+label: "Update NGINX versions"
+---
+```bash
+./scripts/get-nginx-versions.sh --write
+```
+::
+
 ## Helping out
 If you're really eager to help out, here are a few places to get started:
 - Help answer questions on [our GitHub Discussions](https://github.com/serversideup/docker-php/discussions) and [our Discord](https://serversideup.net/discord)

--- a/docs/content/docs/2.getting-started/7.contributing.md
+++ b/docs/content/docs/2.getting-started/7.contributing.md
@@ -110,6 +110,39 @@ label: "Update NGINX versions"
 ```
 ::
 
+### NGINX repository key verification
+
+- **Debian (APT)**: We import the official NGINX GPG key from `https://nginx.org/keys/nginx_signing.key` and verify it against a pinned fingerprint via the `SIGNING_FINGERPRINT` build arg.
+- **Alpine (APK)**: APK uses a raw RSA public key (`nginx_signing.rsa.pub`). We verify this key by pinning the SHA‑256 of the DER‑encoded public key via the `SIGNING_ALPINE_RSA_PUB_SHA256` build arg. You can provide multiple comma‑separated hashes to support key rotation.
+
+Compute the Alpine key hash when updating:
+
+```bash
+curl -sS https://nginx.org/keys/nginx_signing.rsa.pub -o /tmp/nginx_signing.rsa.pub
+# macOS
+openssl rsa -pubin -in /tmp/nginx_signing.rsa.pub -outform DER 2>/dev/null | shasum -a 256 | awk '{print $1}'
+# Linux
+openssl rsa -pubin -in /tmp/nginx_signing.rsa.pub -outform DER 2>/dev/null | sha256sum | awk '{print $1}'
+```
+
+Then build with the new hash (optionally include the old hash during rotation):
+
+```bash
+docker build \
+  --build-arg SIGNING_ALPINE_RSA_PUB_SHA256="<new-hash>,<old-hash>" \
+  -f src/variations/fpm-nginx/Dockerfile .
+```
+
+Reference: [Installing NGINX Open Source → Alpine packages](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-open-source/#prebuilt_alpine).
+
+Why allow multiple hashes? This is optional, but useful during a short rotation window:
+
+- Ensure CI builds across branches/runners succeed while the upstream key change propagates.
+- Avoid flakes from CDN/caching delays where some environments still see the old key.
+- Let you pre-stage the new value before the official switch, then remove the old afterwards.
+
+If you control all builds centrally and can update quickly, pass a single hash.
+
 ## Helping out
 If you're really eager to help out, here are a few places to get started:
 - Help answer questions on [our GitHub Discussions](https://github.com/serversideup/docker-php/discussions) and [our Discord](https://serversideup.net/discord)

--- a/scripts/conf/php-versions-base-config.yml
+++ b/scripts/conf/php-versions-base-config.yml
@@ -78,7 +78,7 @@ operating_systems:
       - name: "Alpine 3.17"
         version: alpine3.17
         number: 3.17
-        nginx_version: 1.26.1-r2
+        nginx_version: 1.26.2-r1
       - name: "Alpine 3.18"
         version: alpine3.18
         number: 3.18

--- a/scripts/conf/php-versions-base-config.yml
+++ b/scripts/conf/php-versions-base-config.yml
@@ -59,7 +59,6 @@ php_versions:
           # - 8.3.6 # Pull latest from Official PHP source
       - minor: "8.4"
         base_os:
-          - name: alpine3.20
           - name: alpine3.21
           - name: alpine3.22
           - name: bookworm

--- a/scripts/conf/php-versions-base-config.yml
+++ b/scripts/conf/php-versions-base-config.yml
@@ -63,14 +63,16 @@ php_versions:
           - name: trixie
         patch_versions:
         #   - 8.4.1 # Pull latest from Official PHP source
-      - minor: "8.5-rc"
-        base_os:
-          - name: alpine3.21
-          - name: alpine3.22
-          - name: bookworm
-          - name: trixie
-        patch_versions:
-          - 8.5-rc
+      # PHP 8.5-rc has a blocking bug in a dependency that is not yet fixed.
+      # 
+      # - minor: "8.5-rc"
+      #   base_os:
+      #     - name: alpine3.21
+      #     - name: alpine3.22
+      #     - name: bookworm
+      #     - name: trixie
+      #   patch_versions:
+      #     - 8.5-rc
 
 operating_systems:
   - family: alpine

--- a/scripts/conf/php-versions-base-config.yml
+++ b/scripts/conf/php-versions-base-config.yml
@@ -12,6 +12,7 @@ php_variations:
     supported_os: # Alpine with Unit is not supported yet. Submit a PR if you can help (https://github.com/serversideup/docker-php/issues/233)
       - bullseye
       - bookworm
+      - trixie
 
 php_versions:
   - major: "7"

--- a/scripts/conf/php-versions-base-config.yml
+++ b/scripts/conf/php-versions-base-config.yml
@@ -12,7 +12,6 @@ php_variations:
     supported_os: # Alpine with Unit is not supported yet. Submit a PR if you can help (https://github.com/serversideup/docker-php/issues/233)
       - bullseye
       - bookworm
-      - trixie
 
 php_versions:
   - major: "7"

--- a/scripts/conf/php-versions-base-config.yml
+++ b/scripts/conf/php-versions-base-config.yml
@@ -1,50 +1,3 @@
-php_versions:
-  - major: "7"
-    minor_versions:
-      - minor: "7.4"
-        base_os:
-          - name: alpine
-          - name: bullseye
-            default: true
-        patch_versions:
-          - 7.4.33
-  - major: "8"
-    minor_versions:
-      - minor: "8.0"
-        base_os:
-          - name: alpine
-          - name: bullseye
-            default: true
-        patch_versions:
-          - 8.0.30
-      - minor: "8.1"
-        base_os:
-          - name: alpine
-          - name: bookworm
-            default: true
-        patch_versions:
-          # - 8.1.28 # Pull latest from Official PHP source
-      - minor: "8.2"
-        base_os:
-          - name: alpine
-          - name: bookworm
-            default: true
-        patch_versions:
-        #   - 8.2.18 # Pull latest from Official PHP source
-      - minor: "8.3"
-        base_os:
-          - name: alpine
-          - name: bookworm
-            default: true
-        patch_versions:
-          # - 8.3.6 # Pull latest from Official PHP source
-      - minor: "8.4"
-        base_os:
-          - name: alpine
-          - name: bookworm
-            default: true
-        patch_versions:
-        #   - 8.4.1 # Pull latest from Official PHP source
 php_variations:
   - name: cli
     default: true
@@ -53,44 +6,111 @@ php_variations:
     supported_os: # Open a discussion on serversideup/php if you want to see Alpine support for fpm-apache (https://github.com/serversideup/docker-php/discussions/66)
       - bullseye
       - bookworm
+      - trixie
   - name: fpm-nginx
   - name: unit
     supported_os: # Alpine with Unit is not supported yet. Submit a PR if you can help (https://github.com/serversideup/docker-php/issues/233)
       - bullseye
       - bookworm
+      - trixie
+
+php_versions:
+  - major: "7"
+    minor_versions:
+      - minor: "7.4"
+        base_os:
+          - name: alpine3.16
+          - name: bullseye
+        patch_versions:
+          - 7.4.33
+  - major: "8"
+    minor_versions:
+      - minor: "8.0"
+        base_os:
+          - name: alpine3.16
+          - name: bullseye
+        patch_versions:
+          - 8.0.30
+      - minor: "8.1"
+        base_os:
+          - name: alpine3.20
+          - name: alpine3.21
+          - name: alpine3.22
+          - name: bookworm
+          - name: trixie
+        patch_versions:
+          # - 8.1.28 # Pull latest from Official PHP source
+      - minor: "8.2"
+        base_os:
+          - name: alpine3.20
+          - name: alpine3.21
+          - name: alpine3.22
+          - name: bookworm
+          - name: trixie
+        patch_versions:
+        #   - 8.2.18 # Pull latest from Official PHP source
+      - minor: "8.3"
+        base_os:
+          - name: alpine3.20
+          - name: alpine3.21
+          - name: alpine3.22
+          - name: bookworm
+          - name: trixie
+        patch_versions:
+          # - 8.3.6 # Pull latest from Official PHP source
+      - minor: "8.4"
+        base_os:
+          - name: alpine3.20
+          - name: alpine3.21
+          - name: alpine3.22
+          - name: bookworm
+          - name: trixie
+        patch_versions:
+        #   - 8.4.1 # Pull latest from Official PHP source
 
 operating_systems:
   - family: alpine
     versions:
       - name: "Alpine 3.16"
         version: alpine3.16
+        number: 3.16
         nginx_version: 1.26.1-r2
       - name: "Alpine 3.17"
         version: alpine3.17
+        number: 3.17
         nginx_version: 1.26.1-r2
       - name: "Alpine 3.18"
         version: alpine3.18
+        number: 3.18
         nginx_version: 1.28.0-r1
       - name: "Alpine 3.19"
         version: alpine3.19
+        number: 3.19
         nginx_version: 1.28.0-r1
       - name: "Alpine 3.20"
         version: alpine3.20
+        number: 3.20
         nginx_version: 1.28.0-r1
       - name: "Alpine 3.21"
         version: alpine3.21
+        number: 3.21
         nginx_version: 1.28.0-r1
       - name: "Alpine 3.22"
         version: alpine3.22
+        number: 3.22
         nginx_version: 1.28.0-r1
   - family: debian
+    default: true
     versions:
       - name: "Debian Bullseye"
         version: bullseye
+        number: 11
         nginx_version: 1.28.0-1~bullseye
       - name: "Debian Bookworm"
         version: bookworm
+        number: 12
         nginx_version: 1.28.0-1~bookworm
       - name: "Debian Trixie"
         version: trixie
+        number: 13
         nginx_version: 1.28.0-1~trixie

--- a/scripts/conf/php-versions-base-config.yml
+++ b/scripts/conf/php-versions-base-config.yml
@@ -32,7 +32,6 @@ php_versions:
           - 8.0.30
       - minor: "8.1"
         base_os:
-          - name: alpine3.20
           - name: alpine3.21
           - name: alpine3.22
           - name: bookworm
@@ -41,7 +40,6 @@ php_versions:
           # - 8.1.28 # Pull latest from Official PHP source
       - minor: "8.2"
         base_os:
-          - name: alpine3.20
           - name: alpine3.21
           - name: alpine3.22
           - name: bookworm
@@ -50,7 +48,6 @@ php_versions:
         #   - 8.2.18 # Pull latest from Official PHP source
       - minor: "8.3"
         base_os:
-          - name: alpine3.20
           - name: alpine3.21
           - name: alpine3.22
           - name: bookworm

--- a/scripts/conf/php-versions-base-config.yml
+++ b/scripts/conf/php-versions-base-config.yml
@@ -63,6 +63,14 @@ php_versions:
           - name: trixie
         patch_versions:
         #   - 8.4.1 # Pull latest from Official PHP source
+      - minor: "8.5-rc"
+        base_os:
+          - name: alpine3.21
+          - name: alpine3.22
+          - name: bookworm
+          - name: trixie
+        patch_versions:
+          - 8.5-rc
 
 operating_systems:
   - family: alpine

--- a/scripts/conf/php-versions-base-config.yml
+++ b/scripts/conf/php-versions-base-config.yml
@@ -58,3 +58,39 @@ php_variations:
     supported_os: # Alpine with Unit is not supported yet. Submit a PR if you can help (https://github.com/serversideup/docker-php/issues/233)
       - bullseye
       - bookworm
+
+operating_systems:
+  - family: alpine
+    versions:
+      - name: "Alpine 3.16"
+        version: alpine3.16
+        nginx_version: 1.26.1-r2
+      - name: "Alpine 3.17"
+        version: alpine3.17
+        nginx_version: 1.26.1-r2
+      - name: "Alpine 3.18"
+        version: alpine3.18
+        nginx_version: 1.28.0-r1
+      - name: "Alpine 3.19"
+        version: alpine3.19
+        nginx_version: 1.28.0-r1
+      - name: "Alpine 3.20"
+        version: alpine3.20
+        nginx_version: 1.28.0-r1
+      - name: "Alpine 3.21"
+        version: alpine3.21
+        nginx_version: 1.28.0-r1
+      - name: "Alpine 3.22"
+        version: alpine3.22
+        nginx_version: 1.28.0-r1
+  - family: debian
+    versions:
+      - name: "Debian Bullseye"
+        version: bullseye
+        nginx_version: 1.28.0-1~bullseye
+      - name: "Debian Bookworm"
+        version: bookworm
+        nginx_version: 1.28.0-1~bookworm
+      - name: "Debian Trixie"
+        version: trixie
+        nginx_version: 1.28.0-1~trixie

--- a/scripts/generate-matrix.sh
+++ b/scripts/generate-matrix.sh
@@ -16,8 +16,14 @@ fi
 yq -o=json "$PHP_VERSIONS_FILE" | jq -c '
 
   def version_weight:
-    # Convert "x.y.z" into a sortable integer weight
-    split(".") | map(tonumber) as $nums | ($nums[0]*10000 + $nums[1]*100 + $nums[2]);
+    # Support numeric patches x.y.z and RC minors x.y-rc
+    if test("-rc$") then
+      capture("^(?<maj>[0-9]+)\\.(?<min>[0-9]+)-rc$") as $m
+      | ($m.maj|tonumber)*10000 + ($m.min|tonumber)*100 + 99
+    else
+      capture("^(?<maj>[0-9]+)\\.(?<min>[0-9]+)\\.(?<pat>[0-9]+)$") as $m
+      | ($m.maj|tonumber)*10000 + ($m.min|tonumber)*100 + ($m.pat|tonumber)
+    end;
 
   def os_family_match($os_name; $supported):
     # Allow listing "alpine" to include any alpine3.xx base_os

--- a/scripts/generate-matrix.sh
+++ b/scripts/generate-matrix.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: generate-matrix.sh [path/to/php-versions.yml]
+# Reads the provided YAML (or $PHP_VERSIONS_FILE, or default scripts/conf/php-versions.yml)
+# and prints a GitHub Actions matrix JSON of the form {"include": [...]}
+
+PHP_VERSIONS_FILE="${1:-${PHP_VERSIONS_FILE:-scripts/conf/php-versions.yml}}"
+
+if [ ! -f "$PHP_VERSIONS_FILE" ]; then
+  echo "YAML file not found: $PHP_VERSIONS_FILE" >&2
+  exit 1
+fi
+
+# Convert YAML to JSON, then shape it with jq.
+yq -o=json "$PHP_VERSIONS_FILE" | jq -c '
+
+  def version_weight:
+    # Convert "x.y.z" into a sortable integer weight
+    split(".") | map(tonumber) as $nums | ($nums[0]*10000 + $nums[1]*100 + $nums[2]);
+
+  def os_family_match($os_name; $supported):
+    # Allow listing "alpine" to include any alpine3.xx base_os
+    # Exact matches like "bullseye", "bookworm", "trixie" must match exactly
+    ($supported == $os_name) or ($supported == "alpine" and ($os_name | startswith("alpine")));
+
+  def is_supported($variation; $os):
+    # If no supported_os specified, allow all; otherwise filter
+    (($variation.supported_os // []) | length) == 0 or
+    ((($variation.supported_os // []) | any(os_family_match($os.name; .))));
+
+  . as $root
+  | [ ($root.php_variations[] | {name, supported_os}) as $variation
+      | $root.php_versions[]
+      | .minor_versions[]
+      | .base_os[] as $os
+      | .patch_versions[] as $patch
+      | select(is_supported($variation; $os))
+      | {patch_version: $patch, base_os: $os.name, php_variation: $variation.name}
+    ]
+  | { include: ( . | sort_by(.patch_version | version_weight) | reverse ) }
+'
+
+

--- a/scripts/get-php-versions.sh
+++ b/scripts/get-php-versions.sh
@@ -108,6 +108,7 @@ if [ "$SKIP_DOWNLOAD" = false ]; then
     # Use 'echo' to pass the JSON data to 'jq'
     merged_json=$(jq -s '
         {
+            php_variations: (.[1].php_variations // []),
             php_versions: (
                 .[0].php_versions + .[1].php_versions
                 | group_by(.major)
@@ -124,7 +125,8 @@ if [ "$SKIP_DOWNLOAD" = false ]; then
                     )
                 })
             ),
-            php_variations: (. | map(.php_variations // []) | add)
+            operating_systems: (.[1].operating_systems // [])
+            
         }
     ' <(echo "$downloaded_and_normalized_json_data") <(echo "$base_json_data"))
 

--- a/scripts/get-php-versions.sh
+++ b/scripts/get-php-versions.sh
@@ -1,14 +1,27 @@
 #!/bin/bash
 ###################################################
-# Usage: get-php-versions.sh [--skip-download]
+# Usage: get-php-versions.sh [--skip-download] [--skip-dockerhub-validation]
 ###################################################
 # This file takes the official latest PHP releases from php.net merges them with our
 # "base php configuration". These files get merged into a final file called "php-versions.yml"
 # which is used to build our GitHub Actions jobs.
 #
+# 🔍 DOCKERHUB VALIDATION & FALLBACK
+# By default, this script validates that each PHP version from php.net is actually available 
+# on DockerHub before including it in the final configuration. If a version is not available:
+# 1. The script attempts to fall back to the previous patch version (e.g., 8.3.24 -> 8.3.23)
+# 2. A GitHub Actions warning is displayed explaining the fallback
+# 3. If the fallback version is also unavailable, the script exits with an error
+#
+# This ensures that Docker builds won't fail due to non-existent base images.
+#
 # 👉 REQUIRED FILES
 # - BASE_PHP_VERSIONS_CONFIG_FILE must be valid and set to a valid file path
 #  (defaults to scripts/conf/php-versions-base-config.yml)
+#
+# 👉 OPTIONS
+# --skip-download: Skip downloading from php.net and use existing base config
+# --skip-dockerhub-validation: Skip DockerHub validation (useful for testing/development)
 
 set -oue pipefail
 
@@ -17,12 +30,143 @@ set -oue pipefail
 # trap read DEBUG
 
 ##########################
+# DockerHub API Functions
+
+# Check if a PHP version exists on DockerHub
+check_dockerhub_php_version() {
+    local version="$1"
+    local variant="${2:-cli}"
+    local os="${3:-}"
+    
+    local image_tag
+    if [ -n "$os" ] && [ "$os" != "bullseye" ] && [ "$os" != "bookworm" ]; then
+        image_tag="${version}-${variant}-${os}"
+    else
+        image_tag="${version}-${variant}"
+    fi
+    
+    # Use Docker Hub API v2 to check if the tag exists with timeout and retry
+    local response
+    local max_retries=3
+    local retry_count=0
+    
+    while [ $retry_count -lt $max_retries ]; do
+        response=$(curl -s --max-time 10 --connect-timeout 5 \
+            -o /dev/null -w "%{http_code}" \
+            "https://registry.hub.docker.com/v2/repositories/library/php/tags/${image_tag}/")
+        
+        # Check if we got a valid HTTP response
+        if [ "$response" = "200" ]; then
+            return 0  # Version exists
+        elif [ "$response" = "404" ]; then
+            return 1  # Version definitely does not exist
+        else
+            # Network error or other issue, retry
+            retry_count=$((retry_count + 1))
+            if [ $retry_count -lt $max_retries ]; then
+                echo_color_message yellow "⚠️  DockerHub API request failed (HTTP $response), retrying in 2 seconds..."
+                sleep 2
+            fi
+        fi
+    done
+    
+    # If we get here, all retries failed
+    echo_color_message red "❌ Failed to check DockerHub after $max_retries attempts for $image_tag"
+    return 1
+}
+
+# Get previous patch version (e.g., 8.3.24 -> 8.3.23)
+get_previous_patch_version() {
+    local version="$1"
+    local major_minor patch
+    
+    # Split version into major.minor and patch
+    major_minor=$(echo "$version" | cut -d'.' -f1-2)
+    patch=$(echo "$version" | cut -d'.' -f3)
+    
+    # Decrement patch version
+    if [ "$patch" -gt 0 ]; then
+        patch=$((patch - 1))
+        echo "${major_minor}.${patch}"
+    else
+        # If patch is 0, we can't go lower
+        return 1
+    fi
+}
+
+# Add a new function for GitHub Actions annotations (around line 193)
+function github_actions_annotation() {
+    local type="$1"        # warning, error, notice, debug
+    local title="$2"       # The title
+    local message="$3"     # The message
+    
+    # Output the official workflow command format
+    echo "::${type} title=${title}::${message}"
+    
+    # Add to step summary for better visibility
+    case "$type" in
+        warning)
+            echo "⚠️ **Warning: ${title}** - ${message}" >> $GITHUB_STEP_SUMMARY
+            ;;
+        error)
+            echo "❌ **Error: ${title}** - ${message}" >> $GITHUB_STEP_SUMMARY
+            ;;
+    esac
+}
+
+# Validate and potentially fallback a PHP version
+validate_php_version_with_fallback() {
+    local version="$1"
+    local original_version="$version"
+    local fallback_attempted=false
+    
+    echo_color_message yellow "🔍 Checking PHP version $version on DockerHub..." >&2
+    
+    # Check if the version exists on DockerHub (using cli variant as reference)
+    if check_dockerhub_php_version "$version" "cli"; then
+        echo_color_message green "✅ PHP $version is available on DockerHub" >&2
+        echo "$version"  # Output to stdout for capture
+        return 0
+    else
+        echo_color_message red "❌ PHP $version is not available on DockerHub" >&2
+        
+        # Try to get previous patch version
+        local fallback_version
+        if fallback_version=$(get_previous_patch_version "$version"); then
+            fallback_attempted=true
+            echo_color_message yellow "⚠️  Attempting fallback to PHP $fallback_version..." >&2
+            
+            if check_dockerhub_php_version "$fallback_version" "cli"; then
+                # Output GitHub Actions annotation without color formatting
+                github_actions_annotation "warning" "PHP Version Fallback" "PHP $original_version is not available on DockerHub. Falling back to PHP $fallback_version. This may indicate that DockerHub has not yet published the latest PHP release. Consider checking DockerHub availability before updating to newer versions."
+                echo_color_message green "✅ Fallback successful: Using PHP $fallback_version" >&2
+                echo "$fallback_version"  # Output to stdout for capture
+                return 0
+            else
+                echo_color_message red "❌ Fallback version PHP $fallback_version is also not available on DockerHub" >&2
+            fi
+        fi
+        
+        # If we get here, both original and fallback failed
+        if [ "$fallback_attempted" = true ]; then
+            github_actions_annotation "error" "PHP Version Unavailable" "Neither PHP $original_version nor fallback version $fallback_version are available on DockerHub. This suggests a significant lag in DockerHub publishing or a configuration issue. Please check DockerHub manually and consider using a known working version."
+        else
+            github_actions_annotation "error" "PHP Version Unavailable" "PHP $original_version is not available on DockerHub and no fallback version could be determined (patch version is 0). Please check DockerHub manually and use a known working version."
+        fi
+        
+        return 1
+    fi
+}
+
+##########################
 # Argument Parsing
 
 SKIP_DOWNLOAD="${SKIP_DOWNLOAD:-false}"
+SKIP_DOCKERHUB_VALIDATION="${SKIP_DOCKERHUB_VALIDATION:-false}"
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --skip-download) SKIP_DOWNLOAD=true ;;
+        --skip-dockerhub-validation) SKIP_DOCKERHUB_VALIDATION=true ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
@@ -75,6 +219,72 @@ if [ "$SKIP_DOWNLOAD" = false ]; then
     echo_color_message yellow "⚡️ Getting PHP Versions from $PHP_VERSIONS_ACTIVE_JSON_FEED"
     # Fetch the JSON from the PHP website
     php_net_version_json=$(curl -s $PHP_VERSIONS_ACTIVE_JSON_FEED)
+
+    # Parse the fetched JSON data and optionally validate PHP versions on DockerHub
+    if [ "$SKIP_DOCKERHUB_VALIDATION" = true ]; then
+        echo_color_message yellow "⚠️  Skipping DockerHub validation as requested..."
+        processed_json="$php_net_version_json"
+    else
+        echo_color_message yellow "🔍 Parsing and validating PHP versions from php.net..."
+        
+        # First, extract versions from the JSON
+        php_versions_raw=$(echo "$php_net_version_json" | jq -r "
+        . as \$major |
+        to_entries[] |
+        .value |
+        to_entries[] |
+        .value.version" | grep -v "null" | sort -u)
+        
+        # Create temporary files to store validation results
+        validated_versions_file=$(mktemp)
+        version_map_file=$(mktemp)
+        
+        # Validate each version
+        validation_failed=false
+        while IFS= read -r version; do
+            if [ -n "$version" ]; then
+                echo_color_message yellow "🔍 Validating PHP $version..."
+                # Capture validation result without color codes
+                if validated_version=$(validate_php_version_with_fallback "$version" | tail -n1); then
+                    # Double check that we got a valid version back
+                    if [ -n "$validated_version" ] && [ "$validated_version" != "VALIDATION_FAILED" ]; then
+                        echo "$version:$validated_version" >> "$validated_versions_file"
+                        if [ "$version" != "$validated_version" ]; then
+                            # Escape special characters for sed
+                            escaped_original=$(echo "$version" | sed 's/[[\.*^$(){}?+|/]/\\&/g')
+                            escaped_validated=$(echo "$validated_version" | sed 's/[[\.*^$(){}?+|/]/\\&/g')
+                            echo "s/${escaped_original}/${escaped_validated}/g" >> "$version_map_file"
+                        fi
+                    else
+                        echo_color_message red "❌ Validation failed for PHP $version"
+                        validation_failed=true
+                    fi
+                else
+                    echo_color_message red "❌ Validation failed for PHP $version"
+                    validation_failed=true
+                fi
+            fi
+        done <<< "$php_versions_raw"
+        
+        # Exit if any validation failed
+        if [ "$validation_failed" = true ]; then
+            echo_color_message red "❌ One or more PHP versions failed validation. Stopping build."
+            rm -f "$validated_versions_file" "$version_map_file"
+            exit 1
+        fi
+        
+        # Apply version substitutions if any fallbacks were used
+        processed_json="$php_net_version_json"
+        if [ -s "$version_map_file" ]; then
+            echo_color_message yellow "📝 Applying version fallbacks..."
+            while IFS= read -r substitution; do
+                processed_json=$(echo "$processed_json" | sed "$substitution")
+            done < "$version_map_file"
+        fi
+        
+        # Clean up temporary files
+        rm -f "$validated_versions_file" "$version_map_file"
+    fi
 
     # Parse the fetched JSON data and transform it to a specific YAML structure using jq and yq.
     php_net_yaml_data=$(echo "$php_net_version_json" | jq -r "

--- a/scripts/view-nginx-versions.sh
+++ b/scripts/view-nginx-versions.sh
@@ -4,7 +4,8 @@
 ###################################################
 # This script fetches the latest NGINX versions available for different
 # operating systems from the official NGINX repositories. By default, it
-# shows all operating systems, but you can filter to a specific OS.
+# shows all operating systems from the base config file, but you can filter
+# to a specific OS if needed.
 
 set -oe pipefail
 

--- a/scripts/view-nginx-versions.sh
+++ b/scripts/view-nginx-versions.sh
@@ -50,7 +50,7 @@ help_menu() {
     echo "Usage: $0 [--os <os>]"
     echo
     echo "This script fetches the latest NGINX versions available for different"
-    echo "operating systems from the official NGINX repositories."
+    echo "operating systems from the PHP base config file."
     echo
     echo "Options:"
     echo "  --os <os>      Filter to a specific operating system"

--- a/scripts/view-nginx-versions.sh
+++ b/scripts/view-nginx-versions.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+###################################################
+# Usage: view-nginx-versions.sh [--os <os>]
+###################################################
+# This script fetches the latest NGINX versions available for different
+# operating systems from the official NGINX repositories. By default, it
+# shows all operating systems, but you can filter to a specific OS.
+
+set -oe pipefail
+
+##########################
+# Configuration
+os_config() {
+    # Resolve config path relative to this script so --help works before SCRIPT_DIR is set
+    local this_script_dir
+    this_script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+    local config_file="$this_script_dir/conf/php-versions-base-config.yml"
+
+    if ! command -v yq >/dev/null 2>&1; then
+        echo "yq is required but not found. Install 'yq' (https://github.com/mikefarah/yq) to continue." 1>&2
+        return 1
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "jq is required but not found. Install 'jq' to continue." 1>&2
+        return 1
+    fi
+
+    yq -r '.operating_systems[] | .family as $f | .versions[] | "\(.version)|\($f)|\(.name)"' "$config_file" \
+    | while IFS='|' read -r version family name; do
+        if [[ "$family" == "alpine" ]]; then
+            # version comes as alpineX.Y (e.g., alpine3.20)
+            key="$version"
+            alpine_num_version="${version#alpine}"
+            url="http://nginx.org/packages/alpine/v${alpine_num_version}/main/x86_64/"
+            pattern='nginx-[0-9][^"\n]*\.apk'
+        else
+            key="$version"
+            url="http://nginx.org/packages/debian/dists/${version}/nginx/binary-amd64/Packages"
+            pattern='^Package: nginx$'
+        fi
+        printf '%s|%s|%s|%s\n' "$key" "$name" "$url" "$pattern"
+    done
+}
+
+##########################
+# Functions
+
+help_menu() {
+    echo "Usage: $0 [--os <os>]"
+    echo
+    echo "This script fetches the latest NGINX versions available for different"
+    echo "operating systems from the official NGINX repositories."
+    echo
+    echo "Options:"
+    echo "  --os <os>      Filter to a specific operating system"
+    echo "  --help, -h     Show this help message"
+    echo
+    echo "Available Operating Systems:"
+    os_config | awk -F'|' '{printf "  %-12s %s\n", $1, $2}'
+    echo
+    echo "Examples:"
+    echo "  $0                    # Show all operating systems"
+    echo "  $0 --os alpine3.20    # Show only Alpine 3.20"
+    echo "  $0 --os bookworm      # Show only Debian Bookworm"
+}
+
+##########################
+# Argument Parsing
+
+FILTER_OS=""
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --os)
+        FILTER_OS="$2"
+        shift 2
+        ;;
+        --help|-h)
+        help_menu
+        exit 0
+        ;;
+        *)
+        echo "Unknown parameter passed: $1"
+        help_menu
+        exit 1
+        ;;
+    esac
+done
+
+##########################
+# Environment Settings
+
+# Script Configurations
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# UI Colors
+function ui_set_yellow {
+    printf $'\033[0;33m'
+}
+
+function ui_set_green {
+    printf $'\033[0;32m'
+}
+
+function ui_set_red {
+    printf $'\033[0;31m'
+}
+
+function ui_set_blue {
+    printf $'\033[0;34m'
+}
+
+function ui_set_bold {
+    printf $'\033[1m'
+}
+
+function ui_reset_colors {
+    printf "\e[0m"
+}
+
+function echo_color_message (){
+  color=$1
+  message=$2
+
+  ui_set_$color
+  echo "$message"
+  ui_reset_colors
+}
+
+##########################
+# Fetch helpers
+
+get_alpine_version() {
+    local url="$1"
+    local pattern="$2"
+    
+    local version=$(curl -s "$url" | grep -o "$pattern" | sort -V | tail -1)
+    if [[ -n "$version" ]]; then
+        # Extract version number from package name (e.g., nginx-1.24.0-r7.apk -> 1.24.0-r7)
+        echo "$version" | sed 's/nginx-\(.*\)\.apk/\1/'
+    else
+        echo "Unable to fetch"
+    fi
+}
+
+get_debian_version() {
+    local url="$1"
+    
+    local version=$(curl -s "$url" \
+        | awk 'BEGIN{RS=""; FS="\n"} { pkg=0; ver=""; for (i=1;i<=NF;i++){ if ($i ~ /^Package: nginx$/) pkg=1; if ($i ~ /^Version:/){ split($i,a,": *"); ver=a[2]; } } if (pkg && ver!="") print ver; }' \
+        | sort -V | tail -1)
+    if [[ -n "$version" ]]; then
+        echo "$version"
+    else
+        echo "Unable to fetch"
+    fi
+}
+
+fetch_nginx_version() {
+    local os_key="$1"
+    local os_name="$2"
+    local url="$3"
+    local pattern="$4"
+    
+    echo_color_message blue "🔍 Fetching NGINX version for $os_name from $url..."
+    
+    local version=""
+    if [[ "$url" == *"alpine"* ]]; then
+        version=$(get_alpine_version "$url" "$pattern")
+    else
+        version=$(get_debian_version "$url")
+    fi
+    
+    ui_set_bold
+    ui_set_green
+    printf "%-20s" "$os_name:"
+    ui_reset_colors
+    echo " $version"
+}
+
+##########################
+# Main script starts here
+
+echo_color_message yellow "🌐 NGINX Version Checker"
+echo
+
+# If a specific OS is requested, validate it exists
+if [[ -n "$FILTER_OS" ]]; then
+    if ! grep -q "^$FILTER_OS|" < <(os_config); then
+        echo_color_message red "❌ Unknown operating system: $FILTER_OS"
+        echo
+        help_menu
+        exit 1
+    fi
+fi
+
+# Process operating systems
+os_config | while IFS='|' read -r os_key os_name url pattern; do
+    # Skip if filtering and this isn't the requested OS
+    if [[ -n "$FILTER_OS" && "$os_key" != "$FILTER_OS" ]]; then
+        continue
+    fi
+
+    fetch_nginx_version "$os_key" "$os_name" "$url" "$pattern"
+done
+
+echo
+echo_color_message green "✅ NGINX version check complete!"

--- a/src/common/usr/local/bin/docker-php-serversideup-install-php-ext-installer
+++ b/src/common/usr/local/bin/docker-php-serversideup-install-php-ext-installer
@@ -11,7 +11,7 @@ script_name="docker-php-serversideup-install-php-ext-installer"
 ############
 # Environment variables
 ############
-PHP_EXT_INSTALLER_VERSION="2.7.0"
+PHP_EXT_INSTALLER_VERSION="2.9.4"
 
 ############
 # Main

--- a/src/common/usr/local/bin/docker-php-serversideup-set-file-permissions
+++ b/src/common/usr/local/bin/docker-php-serversideup-set-file-permissions
@@ -70,19 +70,54 @@ case "$OS" in
     debian)
         case "$SERVICE" in
             cli)
-                DIRS="/var/www/ $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
+                DIRS="
+                    /composer
+                    /var/www
+                    $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             fpm)
-                DIRS="/var/www/ /usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
+                DIRS="
+                    /composer
+                    /usr/local/etc/php-fpm.conf
+                    /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf
+                    /var/www
+                    $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             apache)
-                DIRS="/run /etc/apache2 /etc/ssl/private /var/log/apache2 /var/www/ /usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
+                DIRS="
+                    /composer
+                    /etc/apache2
+                    /etc/ssl/private
+                    /run
+                    /usr/local/etc/php-fpm.conf
+                    /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf
+                    /var/log/apache2
+                    /var/www
+                    $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             nginx)
-                DIRS="/run /etc/nginx/ /var/log/nginx /etc/ssl/private /var/cache/nginx/ /var/www/ /usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
+                DIRS="
+                    /composer
+                    /etc/nginx
+                    /etc/ssl/private
+                    /run
+                    /usr/local/etc/php-fpm.conf
+                    /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf
+                    /var/cache/nginx
+                    /var/log/nginx
+                    /var/www
+                    $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             unit)
-                DIRS="/var/log/unit /var/run/unit /etc/unit /etc/ssl/private/ /var/lib/unit/ /var/www/ $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
+                DIRS="
+                    /composer
+                    /etc/unit
+                    /etc/ssl/private
+                    /var/lib/unit
+                    /var/log/unit
+                    /var/run/unit
+                    /var/www
+                    $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             *)
                 echo "$script_name: Unsupported service: $SERVICE"
@@ -93,16 +128,41 @@ case "$OS" in
     alpine)
         case "$SERVICE" in
             cli)
-                DIRS="/var/www/ $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
+                DIRS="
+                    /composer
+                    /var/www
+                    $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             fpm)
-                DIRS="/var/www/ /usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
+                DIRS="
+                    /composer
+                    /usr/local/etc/php-fpm.conf
+                    /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf
+                    /var/www
+                    $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             apache)
-                DIRS="/etc/apache2 /etc/ssl/private /var/www/ /usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
+                DIRS="
+                    /composer
+                    /etc/apache2
+                    /etc/ssl/private
+                    /run
+                    /usr/local/etc/php-fpm.conf
+                    /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf
+                    /var/www
+                    $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             nginx)
-                DIRS="/etc/nginx/ /var/log/nginx /etc/ssl/private /var/cache/nginx /var/www/ /usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
+                DIRS="
+                    /composer
+                    /etc/nginx/
+                    /etc/ssl/private
+                    /usr/local/etc/php-fpm.conf
+                    /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf
+                    /var/cache/nginx
+                    /var/log/nginx
+                    /var/www/
+                    $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             *)
                 echo "$script_name: Unsupported SERVICE: $SERVICE"

--- a/src/common/usr/local/bin/docker-php-serversideup-set-file-permissions
+++ b/src/common/usr/local/bin/docker-php-serversideup-set-file-permissions
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -eu
 
 ###################################################
 # Usage: docker-php-serversideup-set-file-permissions --owner USER:GROUP --service SERVICE
@@ -16,6 +16,12 @@ usage() {
     echo "Usage: $0 --owner USER:GROUP --service SERVICE"
     exit 1
 }
+
+# Check for root privileges
+if [ "$(id -u)" -ne 0 ]; then
+    echo "${script_name}: This script must be run as root within the container. Be sure to set \"USER root\" in your Dockerfile before running this script."
+    exit 1
+fi
 
 # Check for minimum number of arguments
 if [ "$#" -ne 4 ]; then

--- a/src/common/usr/local/bin/docker-php-serversideup-set-file-permissions
+++ b/src/common/usr/local/bin/docker-php-serversideup-set-file-permissions
@@ -102,7 +102,7 @@ case "$OS" in
                 DIRS="/etc/apache2 /etc/ssl/private /var/www/ /usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             nginx)
-                DIRS="/etc/nginx/ /var/log/nginx /etc/ssl/private /var/lib/nginx /var/www/ /usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
+                DIRS="/etc/nginx/ /var/log/nginx /etc/ssl/private /var/cache/nginx /var/www/ /usr/local/etc/php-fpm.conf /usr/local/etc/php-fpm.d/zzz-docker-php-serversideup-fpm-debug.conf $PHP_INI_DIR/conf.d/zzz-serversideup-docker-php-debug.ini"
                 ;;
             *)
                 echo "$script_name: Unsupported SERVICE: $SERVICE"

--- a/src/s6/usr/local/bin/docker-php-serversideup-s6-install
+++ b/src/s6/usr/local/bin/docker-php-serversideup-s6-install
@@ -9,7 +9,7 @@ set -oue
 # Be sure to set the S6_SRC_URL, S6_SRC_DEP, and S6_DIR
 # environment variables before running this script.
 
-S6_VERSION=v3.2.0.2
+S6_VERSION=v3.2.1.0
 mkdir -p $S6_DIR
 export SYS_ARCH=$(uname -m)
 case "$SYS_ARCH" in

--- a/src/s6/usr/local/bin/docker-php-serversideup-s6-install
+++ b/src/s6/usr/local/bin/docker-php-serversideup-s6-install
@@ -34,5 +34,5 @@ untar ${S6_SRC_URL}/${S6_VERSION}/s6-overlay-${S6_ARCH}.tar.xz
 
 # Ensure "php-fpm-healthcheck" is installed
 echo "⬇️ Downloading php-fpm-healthcheck..."
-curl -o /usr/local/bin/php-fpm-healthcheck https://raw.githubusercontent.com/renatomefi/php-fpm-healthcheck/v0.5.0/php-fpm-healthcheck
+curl -o /usr/local/bin/php-fpm-healthcheck https://raw.githubusercontent.com/renatomefi/php-fpm-healthcheck/v0.6.0/php-fpm-healthcheck
 chmod +x /usr/local/bin/php-fpm-healthcheck

--- a/src/variations/fpm-apache/Dockerfile
+++ b/src/variations/fpm-apache/Dockerfile
@@ -1,3 +1,4 @@
+# check=skip=SecretsUsedInArgOrEnv
 ARG BASE_OS_VERSION='bookworm'
 ARG PHP_VERSION='8.4'
 ARG PHP_VARIATION='fpm-apache'

--- a/src/variations/fpm-nginx/Dockerfile
+++ b/src/variations/fpm-nginx/Dockerfile
@@ -1,3 +1,4 @@
+# check=skip=SecretsUsedInArgOrEnv
 ARG BASE_OS_VERSION='bookworm'
 ARG PHP_VERSION='8.4'
 ARG BASE_IMAGE="php:${PHP_VERSION}-fpm-${BASE_OS_VERSION}"

--- a/src/variations/fpm-nginx/Dockerfile
+++ b/src/variations/fpm-nginx/Dockerfile
@@ -20,42 +20,88 @@ RUN docker-php-serversideup-s6-install
 ####################
 # NGINX Signing Key
 ####################
-FROM php:${PHP_VERSION}-fpm AS nginx-repo-config
+FROM php:${PHP_VERSION}-fpm-${BASE_OS_VERSION} AS nginx-repo-config
 
 ARG SIGNING_KEY_URL="https://nginx.org/keys/nginx_signing.key"
 ARG SIGNING_FINGERPRINT="573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62"
 ARG SIGNING_KEY_OUTPUT_FILE="/usr/share/keyrings/nginx-archive-keyring.gpg"
+ARG SIGNING_ALPINE_RSA_PUB_SHA256="03833138bf6288dcb545f7a154af24f5c63b94931fef6b078cd8061204a44327"
 
 # copy our scripts
 COPY --chmod=755 src/common/ /
 
-RUN docker-php-serversideup-dep-install-debian "curl gnupg2 ca-certificates lsb-release debian-archive-keyring" && \
-    \
-    # Import signing key
-    curl "$SIGNING_KEY_URL" | gpg --dearmor | tee "$SIGNING_KEY_OUTPUT_FILE" && \
-    \
-    # Verify signing key
-    VALID_KEY=$(gpg --dry-run --quiet --no-keyring --import --import-options import-show "$SIGNING_KEY_OUTPUT_FILE" | grep "$SIGNING_FINGERPRINT") && \
-    \
-    if [ -z "$VALID_KEY" ]; then \
-        echo "ERROR: Key did not match signing signature!" && \
+# Install NGINX signing key
+RUN \
+    if [ -f /etc/debian_version ]; then \
+        # Install dependencies
+        apt-get update && \
+        apt-get install -y curl gnupg2 ca-certificates lsb-release debian-archive-keyring && \
+        \
+        # Create GPG home directory
+        mkdir -p /root/.gnupg && \
+        \
+        # Import signing key
+        curl "$SIGNING_KEY_URL" | gpg --dearmor | tee "$SIGNING_KEY_OUTPUT_FILE" && \
+        \
+        # Verify signing key
+        VALID_KEY=$(gpg --dry-run --quiet --no-keyring --import --import-options import-show "$SIGNING_KEY_OUTPUT_FILE" | grep "$SIGNING_FINGERPRINT") && \
+        if [ -z "$VALID_KEY" ]; then \
+            echo "ERROR: Key did not match signing signature!" && \
+            exit 1; \
+        fi && \
+        \
+        # Setup apt repository for stable nginx packages
+        echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] http://nginx.org/packages/debian $(lsb_release -cs) nginx" | tee /etc/apt/sources.list.d/nginx.list && \
+        \
+        # Setup repository pinning to prefer nginx packages over debian packages
+        printf "Package: *\nPin: origin nginx.org\nPin: release o=nginx\nPin-Priority: 900\n" > /etc/apt/preferences.d/99nginx && \
+        \
+        # Create dummy APK files so subsequent unconditional COPY does not fail on Debian
+        mkdir -p /etc/apk/keys && \
+        touch /etc/apk/repositories /etc/apk/keys/nginx_signing.rsa.pub; \
+    elif [ -f /etc/alpine-release ]; then \
+        # Install prerequisites for Alpine
+        apk add --no-cache openssl curl ca-certificates && \
+        \
+        # Set up the APK repository for stable NGINX packages
+        printf "%s%s%s%s%s\n" \
+            "@nginx " \
+            "http://nginx.org/packages/alpine/v" \
+            "$(egrep -o '^[0-9]+\.[0-9]+' /etc/alpine-release)" \
+            "/main" \
+            | tee -a /etc/apk/repositories && \
+        \
+        # Download the NGINX APK RSA repository key
+        curl -o /tmp/nginx_signing.rsa.pub https://nginx.org/keys/nginx_signing.rsa.pub && \
+        \
+        # Verify the key by pinning the SHA-256 of the DER-encoded public key.
+        # Allow multiple hashes (comma-separated) for rotation via build args.
+        CALC_SHA256=$(openssl rsa -pubin -in /tmp/nginx_signing.rsa.pub -outform DER 2>/dev/null | sha256sum | awk '{print $1}') && \
+        printf "%s" "$SIGNING_ALPINE_RSA_PUB_SHA256" | tr ',' '\n' | grep -qx "$CALC_SHA256" || { \
+            echo "ERROR: Alpine NGINX RSA key SHA-256 mismatch. Expected one of [$SIGNING_ALPINE_RSA_PUB_SHA256], got: $CALC_SHA256"; \
+            exit 1; \
+        } && \
+        \
+        # Move the key to APK's trusted keys directory
+        mv /tmp/nginx_signing.rsa.pub /etc/apk/keys/ && \
+        \
+        # Create dummy Debian files so subsequent unconditional COPY does not fail on Alpine
+        mkdir -p /usr/share/keyrings /etc/apt/sources.list.d /etc/apt/preferences.d && \
+        touch /usr/share/keyrings/nginx-archive-keyring.gpg /etc/apt/sources.list.d/nginx.list /etc/apt/preferences.d/99nginx; \
+    else \
+        echo "ERROR: Unsupported or undetected OS. Only Debian-based and Alpine-based systems are handled." && \
         exit 1; \
-    fi && \
-    \
-    # setup apt repository for stable nginx packages
-    echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] http://nginx.org/packages/debian `lsb_release -cs` nginx" | tee /etc/apt/sources.list.d/nginx.list && \
-    \
-    # setup repository pinning to prefer nginx packages over debian packages
-    printf "Package: *\nPin: origin nginx.org\nPin-Priority: 900\n" > /etc/apt/preferences.d/99nginx
+    fi
 
 ##########
 # FPM-NGINX: Main Image
 ##########
 FROM ${BASE_IMAGE}
-ARG DEPENDENCY_PACKAGES_ALPINE='fcgi nginx gettext shadow'
-ARG DEPENDENCY_PACKAGES_DEBIAN='libfcgi-bin nginx gettext-base procps zip'
+ARG DEPENDENCY_PACKAGES_ALPINE='fcgi gettext shadow'
+ARG DEPENDENCY_PACKAGES_DEBIAN='libfcgi-bin gettext-base procps zip'
 ARG DEPENDENCY_PHP_EXTENSIONS='opcache pcntl pdo_mysql pdo_pgsql redis zip'
 ARG REPOSITORY_BUILD_VERSION='dev'
+ARG NGINX_VERSION='1.28.0-1'
 
 LABEL org.opencontainers.image.title="serversideup/php (fpm-nginx)" \
     org.opencontainers.image.description="Supercharge your PHP experience. Based off the official PHP images, serversideup/php includes pre-configured PHP extensions and settings for enhanced performance and security. Optimized for Laravel and WordPress." \
@@ -125,10 +171,12 @@ COPY --from=s6-build /usr/local/bin/php-fpm-healthcheck /usr/local/bin/php-fpm-h
 COPY --from=nginx-repo-config /usr/share/keyrings/nginx-archive-keyring.gpg /usr/share/keyrings/
 COPY --from=nginx-repo-config /etc/apt/sources.list.d/nginx.list /etc/apt/sources.list.d/
 COPY --from=nginx-repo-config /etc/apt/preferences.d/99nginx /etc/apt/preferences.d/
+COPY --from=nginx-repo-config /etc/apk/repositories /etc/apk/repositories
+COPY --from=nginx-repo-config /etc/apk/keys/nginx_signing.rsa.pub /etc/apk/keys/
 
 # install pecl extensions, dependencies, and clean up
-RUN docker-php-serversideup-dep-install-alpine "${DEPENDENCY_PACKAGES_ALPINE}" && \
-    docker-php-serversideup-dep-install-debian "${DEPENDENCY_PACKAGES_DEBIAN}"  && \
+RUN docker-php-serversideup-dep-install-alpine "${DEPENDENCY_PACKAGES_ALPINE} nginx@nginx=${NGINX_VERSION}" && \
+    docker-php-serversideup-dep-install-debian "${DEPENDENCY_PACKAGES_DEBIAN} nginx=${NGINX_VERSION}"  && \
     docker-php-serversideup-install-php-ext-installer && \
     \
     # Ensure /var/www/ has the correct permissions
@@ -157,10 +205,14 @@ RUN docker-php-serversideup-dep-install-alpine "${DEPENDENCY_PACKAGES_ALPINE}" &
     rm -rf /etc/nginx/http.d/ && \
     rm /etc/nginx/nginx.conf && \
     \
-    # Docker doesn't support conditional COPY, so we have to remove the apt directory if we're on Alpine
+    # Docker doesn't support conditional COPY, so remove OS-specific repo/key artifacts that were copied unconditionally
     if cat /etc/os-release | grep -qi 'Alpine'; then \
+        # On Alpine, remove Debian APT artifacts
         rm -rf /usr/share/keyrings/ && \
         rm -rf /etc/apt/; \
+    else \
+        # On Debian, remove Alpine APK artifacts
+        rm -rf /etc/apk/; \
     fi
 
 # Copy our nginx configurations

--- a/src/variations/fpm/Dockerfile
+++ b/src/variations/fpm/Dockerfile
@@ -76,7 +76,7 @@ RUN rm -rf /usr/local/etc/php-fpm.d/*.conf && \
     \
     # Ensure "php-fpm-healthcheck" is installed
     echo "⬇️ Downloading php-fpm-healthcheck..." && \
-    curl -o /usr/local/bin/php-fpm-healthcheck https://raw.githubusercontent.com/renatomefi/php-fpm-healthcheck/v0.5.0/php-fpm-healthcheck && \
+    curl -o /usr/local/bin/php-fpm-healthcheck https://raw.githubusercontent.com/renatomefi/php-fpm-healthcheck/v0.6.0/php-fpm-healthcheck && \
     chmod +x /usr/local/bin/php-fpm-healthcheck && \
     \
     # Install default PHP extensions

--- a/src/variations/unit/Dockerfile
+++ b/src/variations/unit/Dockerfile
@@ -1,3 +1,4 @@
+# check=skip=SecretsUsedInArgOrEnv
 ARG BASE_OS_VERSION='bookworm'
 ARG PHP_VERSION='8.4'
 ARG PHP_VARIATION='unit'

--- a/src/variations/unit/Dockerfile
+++ b/src/variations/unit/Dockerfile
@@ -10,7 +10,7 @@ ARG BASE_IMAGE="php:${PHP_VERSION}-cli-${BASE_OS_VERSION}"
 FROM ${BASE_IMAGE} AS build
 ARG DEPENDENCY_PACKAGES_ALPINE='build-base curl tar git openssl-dev pcre2-dev shadow'
 ARG DEPENDENCY_PACKAGES_DEBIAN='ca-certificates git build-essential libssl-dev libpcre2-dev curl pkg-config'
-ARG NGINX_UNIT_VERSION='1.33.0-1'
+ARG NGINX_UNIT_VERSION='1.34.2'
 
 # copy our scripts
 COPY --chmod=755 src/common/ /


### PR DESCRIPTION
# 👉 What this PR does
This PR adds a number of improvements to the project, making it easier to maintain and keep our dependencies updated.

# 👨‍🔬 Test this PR
You can test the latest changes on our [serversideup/php-dev repo on DockerHub](https://hub.docker.com/r/serversideup/php-dev/tags?name=554-):

```
serversideup/php-dev:554-*
```

(Any thing prefixed with `554` [the PR number] is built from this PR)

If you notice an issues, please open an issue on GitHub and specifically include the versions that you're having issues with.

# 🤩 What's new

#### All images
- Adds support for Debian Trixie 🥳
- Greatly expanded support for many different versions of operating systems (Alpine 3.22, 3.21, etc)

#### FPM-NGINX
- Changes `fpm-nginx` to install from the official NGINX repos with specific version pinning

#### Unit
- Bumped NGINX Unit to v1.34.2

## 🐛 Bug Fixes
- Fixed issue where Alpine images were the `/run` directory was not being changed when running `docker-php-serversideup-set-file-permissions`

## 🤖 CI Improvements
- Adds CI runners from [depot.dev](https://depot.dev) -- who graciously offered this service to us at no charge 🙏
- Improves CI running process where it runs a build but can "fallback" to a previous minor version if PHP hasn't published a Docker image yet

## ⏫️ Upstream Dependencies
- Bumped [mlocati/docker-php-extension-installer](https://github.com/mlocati/docker-php-extension-installer) to v2.8.0
- Bumped S6 Overlay to v3.2.1.0
- Bumped php-fpmhealthcheck to v0.6.0