### PR TITLE
Add frankenphp-builder variant

### DIFF
--- a/scripts/conf/php-versions-base-config.yml
+++ b/scripts/conf/php-versions-base-config.yml
@@ -14,6 +14,12 @@ php_variations:
       - "8.0"
       - "8.1"
       - "8.2"
+  - name: frankenphp-builder
+    excluded_minor_versions:
+      - "7.4"
+      - "8.0"
+      - "8.1"
+      - "8.2"
   - name: unit
     supported_os: # Alpine with Unit is not supported yet. Submit a PR if you can help (https://github.com/serversideup/docker-php/issues/233)
       - bullseye

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -105,6 +105,11 @@ build_docker_image() {
     build_args+=(--build-arg "NGINX_VERSION=$NGINX_VERSION")
   fi
 
+  if [ "$PHP_BUILD_VARIATION" = "frankenphp-builder" ]; then
+    PHP_BUILD_VARIATION="frankenphp"
+    build_args+=(--target frankenphp-build)
+  fi
+
   docker buildx build \
     "${DOCKER_ADDITIONAL_BUILD_ARGS[@]}" \
     --platform "$PLATFORM" \


### PR DESCRIPTION
I'm not sure if this is the best way to do it, but I added the build target for frankenphp to allow building and adding in extra
modules.   It seems to work.

e.g.

```
FROM serversideup/php:8.4.2-frankenphp-builder-bookworm AS builder

# Copy xcaddy in the builder image
COPY --from=caddy:builder /usr/bin/xcaddy /usr/bin/xcaddy

# CGO must be enabled to build FrankenPHP
RUN CGO_ENABLED=1 \
    XCADDY_SETCAP=1 \
    XCADDY_GO_BUILD_FLAGS="-ldflags='-w -s' -tags=nobadger,nomysql,nopgx" \
    CGO_CFLAGS=$(php-config --includes) \
    CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" \
    xcaddy build \
        --output /usr/local/bin/frankenphp \
        --with github.com/dunglas/frankenphp=./ \
        --with github.com/dunglas/frankenphp/caddy=./caddy/ \
        --with github.com/dunglas/caddy-cbrotli \
        # Mercure and Vulcain are included in the official build, but feel free to remove them
        --with github.com/dunglas/mercure/caddy \
        --with github.com/dunglas/vulcain/caddy 
        # Add extra Caddy modules here

FROM serversideup/php:8.4.2-frankenphp-bookworm AS runner

# Replace the official binary by the one contained your custom modules
COPY --from=builder /usr/local/bin/frankenphp /usr/local/bin/frankenphp
```