### PR TITLE
Refactor and improve security headers, file blocks, etc

### DIFF
--- a/src/variations/fpm-apache/etc/apache2/conf-available/security.conf
+++ b/src/variations/fpm-apache/etc/apache2/conf-available/security.conf
@@ -1,64 +1,73 @@
-#
-# Disable access to the entire file system except for the directories that
-# are explicitly allowed later.
-#
-# This currently breaks the configurations that come with some web application
-# Debian packages.
-#
-#<Directory />
-#   AllowOverride None
-#   Require all denied
-#</Directory>
+##
+# Security Configuration
+##
 
-
-# Changing the following options will not really affect the security of the
-# server, but might make attacks slightly more difficult in some cases.
-
+# This configuration follows security best practices from:
 #
-# ServerTokens
-# This directive configures what you return as the Server HTTP response
-# Header. The default is 'Full' which sends information about the OS-Type
-# and compiled in modules.
-# Set to one of:  Full | OS | Minimal | Minor | Major | Prod
-# where Full conveys the most information, and Prod the least.
-#ServerTokens Minimal
-# ServerTokens OS
-# #ServerTokens Full
+#   H5BP Server Configs (Apache)
+#   https://github.com/h5bp/server-configs-apache
+#
+#   OWASP Secure Headers Project
+#   https://owasp.org/www-project-secure-headers/
+#
+#   RFC 8615 - Well-Known URIs
+#   https://www.rfc-editor.org/rfc/rfc8615
+#
+# ##############################################################################
+
+# ------------------------------------------------------------------------------
+# | Server Software Information                                                |
+# ------------------------------------------------------------------------------
+
+# Minimize information sent about the server
+# https://httpd.apache.org/docs/current/mod/core.html#servertokens
 ServerTokens Prod
 
-#
-# Optionally add a line containing the server version and virtual host
-# name to server-generated pages (internal error documents, FTP directory
-# listings, mod_status and mod_info output etc., but not CGI generated
-# documents or custom error documents).
-# Set to "EMail" to also include a mailto: link to the ServerAdmin.
-# Set to one of:  On | Off | EMail
+# Disable server signature on error pages
+# https://httpd.apache.org/docs/current/mod/core.html#serversignature
 ServerSignature Off
-# ServerSignature On
 
-#
-# Allow TRACE method
-#
-# Set to "extended" to also reflect the request body (only for testing and
-# diagnostic purposes).
-#
-# Set to one of:  On | Off | extended
+# Disable TRACE HTTP method to prevent XST attacks
+# https://owasp.org/www-community/attacks/Cross_Site_Tracing
 TraceEnable Off
-#TraceEnable On
 
-#
-# Forbid access to version control directories
-#
-# If you use version control systems in your document root, you should
-# probably deny access to their directories. For example, for subversion:
-#
-<DirectoryMatch "/\.git">
-   Require all denied
+# ------------------------------------------------------------------------------
+# | Security Headers                                                           |
+# ------------------------------------------------------------------------------
+
+# Prevent clickjacking attacks by disabling iframe embedding
+# https://owasp.org/www-project-secure-headers/#x-frame-options
+Header always set X-Frame-Options "SAMEORIGIN"
+
+# Prevent MIME type sniffing attacks
+# https://owasp.org/www-project-secure-headers/#x-content-type-options
+Header always set X-Content-Type-Options "nosniff"
+
+# Control referrer information sent with requests
+# https://owasp.org/www-project-secure-headers/#referrer-policy
+Header always set Referrer-Policy "strict-origin-when-cross-origin"
+
+# Enable HTTP Strict Transport Security (HSTS)
+# https://owasp.org/www-project-secure-headers/#strict-transport-security
+Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+
+# ------------------------------------------------------------------------------
+# | File Access Restrictions                                                   |
+# ------------------------------------------------------------------------------
+
+# Block access to all hidden files and directories (dotfiles)
+# EXCEPT for the "/.well-known/" directory which is required by RFC 8615
+# for ACME challenges, security.txt, and other standardized endpoints.
+# https://www.rfc-editor.org/rfc/rfc8615
+# https://github.com/h5bp/server-configs-apache
+<DirectoryMatch "/\.(?!well-known/)">
+    Require all denied
 </DirectoryMatch>
 
-# Prevent Apache from serving Gitlab files
-<FilesMatch "\.gitlab-ci.yml$">
-   Require all denied
+# Block access to files that may expose sensitive information
+# Based on H5BP server configs: https://github.com/h5bp/server-configs-apache
+<FilesMatch "(^#.*#|\.(bak|conf|config|dist|inc|ini|log|sh|sql|sw[op])|~)$">
+    Require all denied
 </FilesMatch>
 
 # Disable XML-RPC on all wordpress sites
@@ -66,33 +75,3 @@ TraceEnable Off
    Require all denied
 # allow from xxx.xxx.xxx.xxx
 </Files>
-
-#
-# Setting this header will prevent MSIE from interpreting files as something
-# else than declared by the content type in the HTTP headers.
-# Requires mod_headers to be enabled.
-#
-Header always set X-Content-Type-Options: "nosniff"
-
-#
-# Setting this header will prevent other sites from embedding pages from this
-# site as frames. This defends against clickjacking attacks.
-# Requires mod_headers to be enabled.
-#
-Header always set X-Frame-Options: "sameorigin"
-
-#
-# Referrer policy
-#
-Header always set Referrer-Policy "no-referrer-when-downgrade"
-
-#
-# Content Security Policy
-# UPDATE - September 2020: Commenting this out until we grasp better security requirements
-# 
-#Header always set Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'"
-
-#
-# Strict-Transport-Security Policy (set HSTS)
-#
-Header always set Strict-Transport-Security "max-age=15552000; includeSubDomains"

--- a/src/variations/fpm-nginx/etc/nginx/server-opts.d/security.conf
+++ b/src/variations/fpm-nginx/etc/nginx/server-opts.d/security.conf
@@ -1,24 +1,51 @@
-#
-# Security Headers
-#
+##
+# Security Configuration
+##
 
-# Prevent IFRAME spoofing attacks
+# This configuration follows security best practices from:
+#
+#   H5BP Server Configs (nginx)
+#   https://github.com/h5bp/server-configs-nginx
+#
+#   OWASP Secure Headers Project
+#   https://owasp.org/www-project-secure-headers/
+#
+#   RFC 8615 - Well-Known URIs
+#   https://www.rfc-editor.org/rfc/rfc8615
+#
+# ##############################################################################
+
+# Prevent clickjacking attacks by disabling iframe embedding
+# https://owasp.org/www-project-secure-headers/#x-frame-options
 add_header X-Frame-Options           "SAMEORIGIN" always;
 
-# Prevent MIME attacks
+# Prevent MIME type sniffing attacks
+# https://owasp.org/www-project-secure-headers/#x-content-type-options
 add_header X-Content-Type-Options    "nosniff" always;
 
-# Prevent Referrer URL from being leaked
-add_header Referrer-Policy           "no-referrer-when-downgrade" always;
+# Control referrer information sent with requests
+# https://owasp.org/www-project-secure-headers/#referrer-policy
+add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
 
-# Configure Content Security Policy
-# UPDATE - September 2020: Commenting this out until we grasp better security requirements
-#add_header Content-Security-Policy   "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
-
-# Enable HSTS
+# Enable HTTP Strict Transport Security (HSTS)
+# https://owasp.org/www-project-secure-headers/#strict-transport-security
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
-# Prevent access to . files (the well-known directory)
+# ------------------------------------------------------------------------------
+# | File Access Restrictions                                                   |
+# ------------------------------------------------------------------------------
+
+# Block access to hidden files and directories (dotfiles)
+# EXCEPT for the "/.well-known/" directory which is required by RFC 8615
+# for ACME challenges, security.txt, and other standardized endpoints.
+# https://www.rfc-editor.org/rfc/rfc8615
+# https://github.com/h5bp/server-configs-nginx
 location ~ /\.(?!well-known) {
+    deny all;
+}
+
+# Block access to files that may expose sensitive information
+# Based on H5BP server configs: https://github.com/h5bp/server-configs-nginx
+location ~* (?:#.*#|\.(?:bak|conf|config|dist|inc|ini|log|sh|sql|sw[op])|~)$ {
     deny all;
 }

--- a/src/variations/frankenphp/etc/frankenphp/Caddyfile
+++ b/src/variations/frankenphp/etc/frankenphp/Caddyfile
@@ -127,28 +127,38 @@ fd00::/8 \
 }
 
 (security) {
-	# Reject dot files and certain file extensions, excluding .well-known/
-	@rejected {
-	  path *.bak *.conf *.dist *.fla *.ini *.inc *.inci *.log *.orig *.psd *.sh *.sql *.swo *.swp *.swop */.*
-      # .well-known needs to be whitelisted, further handling in php-app-common
-      not path /.well-known/*
-    }
+	# This configuration follows security best practices from:
+	#
+	#   H5BP Server Configs (nginx) - Adapted for Caddy
+	#   https://github.com/h5bp/server-configs-nginx
+	#
+	#   OWASP Secure Headers Project
+	#   https://owasp.org/www-project-secure-headers/
+	#
+	#   RFC 8615 - Well-Known URIs
+	#   https://www.rfc-editor.org/rfc/rfc8615
 
-	# Return 403 Forbidden for rejected files
+	# Block access to files that may expose sensitive information
+	@rejected {
+		path *.bak *.conf *.config *.dist *.inc *.ini *.log *.sh *.sql *.swp *.swo *~ */.*
+		# EXCEPTION: /.well-known/* is allowed per RFC 8615 for ACME challenges
+		# https://www.rfc-editor.org/rfc/rfc8615
+		not path /.well-known/*
+	}
 	respond @rejected 403
 
-	# Security headers
+	# Security Headers
+	# https://owasp.org/www-project-secure-headers/
 	header {
 		defer
-		# Prevent IFRAME spoofing attacks
+		# Prevent clickjacking attacks by disabling iframe embedding
 		X-Frame-Options "SAMEORIGIN"
-		# Prevent MIME type sniffing
+		# Prevent MIME type sniffing attacks
 		X-Content-Type-Options "nosniff"
-		# Prevent referrer leakage
+		# Control referrer information sent with requests
 		Referrer-Policy "strict-origin-when-cross-origin"
-		# Prevent server header leakage
+		# Remove server identification headers
 		-Server
-		# Prevent powered by header leakage
 		-X-Powered-By
 	}
 }


### PR DESCRIPTION
> [!IMPORTANT]
> This PR was co-authored by @jaydrogers and had it's original comment modified to provide the latest summary. View the original post by @marns93 below if you'd like to see the content of the original submission 

# Testing this PR
You can test this PR by using any tag with this prefix:

```bash
docker.io/serversideup/php-dev:631-*
```

[View related images →](https://hub.docker.com/r/serversideup/php-dev/tags?name=631)

# Summary
This PR standardizes and improves security configurations across **nginx**, **Apache**, and **FrankenPHP/Caddy** variations to ensure consistent behavior and proper documentation with references to authoritative sources.

### Authoritative Sources Referenced
All configurations now cite their sources for transparency and credibility:

| Source | URL |
|--------|-----|
| **H5BP Server Configs (nginx)** | https://github.com/h5bp/server-configs-nginx |
| **H5BP Server Configs (Apache)** | https://github.com/h5bp/server-configs-apache |
| **OWASP Secure Headers Project** | https://owasp.org/www-project-secure-headers/ |
| **RFC 8615 - Well-Known URIs** | https://www.rfc-editor.org/rfc/rfc8615 |

---

### Security Headers (Consistent Across All Variations)

| Header | Value | Purpose |
|--------|-------|---------|
| `X-Frame-Options` | `SAMEORIGIN` | Prevent clickjacking attacks |
| `X-Content-Type-Options` | `nosniff` | Prevent MIME type sniffing |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Control referrer information |
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | Enforce HTTPS (HSTS) |

---

### Blocked File Extensions

Based on H5BP server configs with a **conservative approach** to avoid breaking legitimate use cases:

| Extension | Reason |
|-----------|--------|
| `.bak` | Backup files |
| `.conf` | Configuration files (Linux/Unix) |
| `.config` | Configuration files (Windows/.NET) |
| `.dist` | Distribution/sample configs |
| `.inc` | PHP include files |
| `.ini` | Configuration files |
| `.log` | Log files |
| `.sh` | Shell scripts |
| `.sql` | Database dumps |
| `.swp` / `.swo` | Vim swap files |
| `~` | Editor backup files |
| `#*#` | Emacs auto-save files |
| `*/.*` | All dotfiles (hidden files) |

#### ✅ Explicitly Allowed
- `/.well-known/*` - Required by **RFC 8615** for ACME challenges other standardized endpoints

#### ❌ Intentionally NOT Blocked (too aggressive for general use)
- `.zip`, `.tar`, `.tgz` - Legitimate downloads
- `.yml`, `.json` - Could be API responses
- `.psd`, `.fla` - Low security risk

---

### Key Changes from Previous Configuration

1. **Standardized blocklist** - All three variations now block the same file extensions
2. **Added `.well-known` exception** - Properly allows RFC 8615 endpoints (fixes #626)
3. **Added `.conf` blocking** - More relevant for Linux/PHP environments than `.config` alone
4. **Removed arbitrary extensions** - `.fla`, `.psd`, `.orig`, `.inci`, `.swop` removed (not in official H5BP or too aggressive)
5. **Consistent `Referrer-Policy`** - Changed to `strict-origin-when-cross-origin` across all variations
6. **Added source documentation** - Every rule now cites its authoritative source

---

### Testing Checklist
- [x] Verify `/.well-known/` paths are accessible (ACME, security.txt, etc.)
- [x] Verify blocked extensions return 403
- [x] Verify security headers are present in responses
- [x] Test with legitimate `.zip` downloads (should work)

# Original post by @marns93 

> Fixes: https://github.com/serversideup/docker-php/issues/626
> 
> The newest variation `frankenphp` is blocking everything under `.well-known/`. The following line is responsible for this
> https://github.com/serversideup/docker-php/blob/9b6868e8facc60b4f17a8898c8eb85c3db10c801/src/variations/frankenphp/etc/frankenphp/Caddyfile#L131
> 
> In this PR I've whitelisted some commonly used paths under `.well-known/`. For security reasons I don't want to allow everything, so I've whitelisted some of them. The list can be extended in the future.
