### PR TITLE
Update PHP base opertating systems. Add Alpine 3.23 support

### DIFF
--- a/scripts/conf/php-versions-base-config.yml
+++ b/scripts/conf/php-versions-base-config.yml
@@ -35,42 +35,43 @@ php_versions:
       - minor: "8.1"
         base_os:
           - name: alpine3.21
+          - name: alpine3.22
           - name: bookworm
           - name: trixie
         patch_versions:
-          # - 8.1.28 # Pull latest from Official PHP source
+          # - 8.1.34 # Pull latest from Official PHP source
       - minor: "8.2"
         base_os:
-          - name: alpine3.21
           - name: alpine3.22
+          - name: alpine3.23
           - name: bookworm
           - name: trixie
         patch_versions:
-        #   - 8.2.18 # Pull latest from Official PHP source
+        #   - 8.2.30 # Pull latest from Official PHP source
       - minor: "8.3"
         base_os:
-          - name: alpine3.21
           - name: alpine3.22
+          - name: alpine3.23
           - name: bookworm
           - name: trixie
         patch_versions:
-          # - 8.3.6 # Pull latest from Official PHP source
+          # - 8.3.29 # Pull latest from Official PHP source
       - minor: "8.4"
         base_os:
-          - name: alpine3.21
           - name: alpine3.22
+          - name: alpine3.23
           - name: bookworm
           - name: trixie
         patch_versions:
-        #   - 8.4.1 # Pull latest from Official PHP source
+        #   - 8.4.16 # Pull latest from Official PHP source
       - minor: "8.5"
         base_os:
-          - name: alpine3.21
           - name: alpine3.22
+          - name: alpine3.23
           - name: bookworm
           - name: trixie
         patch_versions:
-        #   - 8.5.0 # Pull latest from Official PHP source
+        #   - 8.5.1 # Pull latest from Official PHP source
 
 operating_systems:
   - family: alpine
@@ -102,6 +103,10 @@ operating_systems:
       - name: "Alpine 3.22"
         version: alpine3.22
         number: 3.22
+        nginx_version: 1.28.0-r1
+      - name: "Alpine 3.23"
+        version: alpine3.23
+        number: 3.23
         nginx_version: 1.28.0-r1
   - family: debian
     default: true


### PR DESCRIPTION
PHP repo no longer has images available for alpine3.21 for latest minor versions, this removes 3.21 if its no longer available and adds 3.23 if available