### PR TITLE
Add security measures to block PHP execution in storage directory

### DIFF
--- a/src/variations/fpm-apache/etc/apache2/conf-available/security.conf
+++ b/src/variations/fpm-apache/etc/apache2/conf-available/security.conf
@@ -55,6 +55,12 @@ Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains
 # | File Access Restrictions                                                   |
 # ------------------------------------------------------------------------------
 
+# Block PHP execution in storage directory to prevent uploaded malicious PHP files from running
+# Reference: Livewire arbitrary file upload (GHSA-29cq-5w36-x7w3)
+<LocationMatch "^/storage/.*\.php$">
+    Require all denied
+</LocationMatch>
+
 # Block access to all hidden files and directories (dotfiles)
 # EXCEPT for the "/.well-known/" directory which is required by RFC 8615
 # for ACME challenges, security.txt, and other standardized endpoints.

--- a/src/variations/fpm-nginx/etc/nginx/site-opts.d/http.conf.template
+++ b/src/variations/fpm-nginx/etc/nginx/site-opts.d/http.conf.template
@@ -30,6 +30,12 @@ location / {
     try_files $uri $uri/ /index.php?$query_string;
 }
 
+# Block PHP execution in storage directory to prevent uploaded malicious PHP files from running
+# Reference: Livewire arbitrary file upload (GHSA-29cq-5w36-x7w3)
+location ~* ^/storage/.*\.php$ {
+    deny all;
+}
+
 # Pass "*.php" files to PHP-FPM
 location ~ \.php$ {
     fastcgi_pass   127.0.0.1:9000;

--- a/src/variations/fpm-nginx/etc/nginx/site-opts.d/https.conf.template
+++ b/src/variations/fpm-nginx/etc/nginx/site-opts.d/https.conf.template
@@ -36,6 +36,12 @@ location / {
     try_files $uri $uri/ /index.php?$query_string;
 }
 
+# Block PHP execution in storage directory to prevent uploaded malicious PHP files from running
+# Reference: Livewire arbitrary file upload (GHSA-29cq-5w36-x7w3)
+location ~* ^/storage/.*\.php$ {
+    deny all;
+}
+
 # Pass "*.php" files to PHP-FPM
 location ~ \.php$ {
     fastcgi_pass   127.0.0.1:9000;

--- a/src/variations/frankenphp/etc/frankenphp/Caddyfile
+++ b/src/variations/frankenphp/etc/frankenphp/Caddyfile
@@ -138,6 +138,11 @@ fd00::/8 \
 	#   RFC 8615 - Well-Known URIs
 	#   https://www.rfc-editor.org/rfc/rfc8615
 
+	# Block PHP execution in storage directory to prevent uploaded malicious PHP files from running
+	# Reference: Livewire arbitrary file upload (GHSA-29cq-5w36-x7w3)
+	@storage-php path_regexp ^/storage/.*\.php$
+	respond @storage-php 403
+
 	# Block access to files that may expose sensitive information
 	@rejected {
 		path *.bak *.conf *.config *.dist *.inc *.ini *.log *.sh *.sql *.swp *.swo *~ */.*


### PR DESCRIPTION
# Background
In July 2025, there was a [9.2 CVE disclosed for Laravel Livewire](https://github.com/livewire/livewire/security/advisories/GHSA-29cq-5w36-x7w3) that allowed unauthenticated attackers to achieve remote command execution in specific scenarios.

# How this exploit was used in the wild
One of our community members (@xaimes) noticed in some scenarios, attackers were using the vulnerability to preform further code execution by executing PHP scripts from the Laravel `/storage` directory.

# How this applies to serversideup/php
Although the exploit was not from the serversideup/php image itself, we're using this as an opportunity to further harden our images to protect the community.

# What this PR does
This PR prevents any `.php` file from being executed that is found in the `/storage/*` path.

For example, if someone visits:
```
https://example.com/storage/nested/in/some/deep/path/exploit.php
```

A `403 Forbidden` message will be returned.

> [!NOTE]
> This rule applies regardless if you're using Laravel or not. We felt this is a general enough of a directory name it is safe to apply to all PHP application types.

## Variations this affects
This rule applies to:
1. FrankenPHP
2. FPM-NGINX
3. FPM-Apache

 