### PR TITLE
Integrate Depot CLI setup and update Docker build action in GitHub workflow

### DIFF
--- a/.github/workflows/service_docker-build-and-publish.yml
+++ b/.github/workflows/service_docker-build-and-publish.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Move PHP Versions file
         run: mv ./artifacts/php-versions.yml ${{ inputs.php-versions-file }}
       
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
+      
       ##
       # Docker build & publish
       ##
@@ -110,12 +113,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: "📦 Assemble the Docker Tags"
         run: |
@@ -167,11 +164,11 @@ jobs:
           echo "nginx_arg=NGINX_VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Build images
-        uses: docker/build-push-action@v6
+        uses: depot/build-push-action@v1
         with:
+          project: ${{ secrets.DEPOT_PROJECT_ID }}
+          token: ${{ secrets.DEPOT_PROJECT_TOKEN }}
           file: src/variations/${{ matrix.php_variation }}/Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha
           build-args: |
             BASE_OS_VERSION=${{ matrix.base_os }}
             PHP_VERSION=${{ matrix.patch_version }}


### PR DESCRIPTION
### What this PR does
- Added step to set up Depot CLI in the Docker build and publish workflow.
- Replaced Docker build-push-action with Depot's version for improved integration.
- Removed unnecessary QEMU and Buildx setup steps.