### PR TITLE
Security: Update NGINX version for Alpine and Debian configurations to 1.28.3

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,29 @@
 # Security Policy
 
-## Supported Versions
-The following versions of PHP are being actively updated:
+## PHP upstream support (php.net)
 
-| PHP Version | Supported          |
-| ------- | ------------------ |
-| 8.5  | :white_check_mark: Active support |
-| 8.4  | :white_check_mark: Active support |
-| 8.3  | :warning: Security updates only |
-| 8.2  | :warning: Security updates only |
-| 8.1  | :heavy_exclamation_mark: End of life, update ASAP |
-| 8.0  | :heavy_exclamation_mark: End of life, update ASAP |
-| 7.4  | :heavy_exclamation_mark: End of life, update ASAP |
-| 7.3  | :x: Not supported |
+The table below is the **official PHP project** support phase for each branch—not a guarantee that every branch appears in our image matrix. Use it to decide when to upgrade.
 
-View the official [PHP supported versions policy](https://www.php.net/supported-versions.php) for more information.
+| Branch | Phase on php.net |
+| --- | --- |
+| 8.5 | Active support (bug + security fixes) |
+| 8.4 | Active support (bug + security fixes) |
+| 8.3 | Security fixes only |
+| 8.2 | Security fixes only |
+| 8.1 | End of life — upgrade as soon as practical |
+| 8.0 | End of life — upgrade as soon as practical |
+| 7.4 | End of life — upgrade as soon as practical |
+| ≤ 7.3 | End of life — not built in this project’s current matrix |
 
-## Reporting a Vulnerability
+**References**
 
-If you have a vulnerability to report, please follow [our responsible disclosure policy](https://www.notion.so/Responsible-Disclosure-Policy-421a6a3be1714d388ebbadba7eebbdc8).
+- [Supported Versions](https://www.php.net/supported-versions.php) — active and security support dates for current branches  
+- [End-of-life branches](https://www.php.net/eol.php) — historical EOL dates  
+
+We may still ship images for **EOL** PHP versions to help migrate legacy apps; prefer a [currently supported branch](https://www.php.net/supported-versions.php) for production.
+
+---
+
+## Reporting a vulnerability
+
+Follow [our responsible disclosure policy](https://www.notion.so/Responsible-Disclosure-Policy-421a6a3be1714d388ebbadba7eebbdc8).

--- a/scripts/conf/php-versions-base-config.yml
+++ b/scripts/conf/php-versions-base-config.yml
@@ -95,31 +95,31 @@ operating_systems:
       - name: "Alpine 3.20"
         version: alpine3.20
         number: 3.20
-        nginx_version: 1.28.2-r1
+        nginx_version: 1.28.3-r1
       - name: "Alpine 3.21"
         version: alpine3.21
         number: 3.21
-        nginx_version: 1.28.2-r1
+        nginx_version: 1.28.3-r1
       - name: "Alpine 3.22"
         version: alpine3.22
         number: 3.22
-        nginx_version: 1.28.2-r1
+        nginx_version: 1.28.3-r1
       - name: "Alpine 3.23"
         version: alpine3.23
         number: 3.23
-        nginx_version: 1.28.2-r1
+        nginx_version: 1.28.3-r1
   - family: debian
     default: true
     versions:
       - name: "Debian Bullseye"
         version: bullseye
         number: 11
-        nginx_version: 1.28.2-1~bullseye
+        nginx_version: 1.28.3-1~bullseye
       - name: "Debian Bookworm"
         version: bookworm
         number: 12
-        nginx_version: 1.28.2-1~bookworm
+        nginx_version: 1.28.3-1~bookworm
       - name: "Debian Trixie"
         version: trixie
         number: 13
-        nginx_version: 1.28.2-1~trixie
+        nginx_version: 1.28.3-1~trixie


### PR DESCRIPTION
## Summary

Updates **Alpine 3.20+** and **all Debian suites** install **NGINX 1.28.3** (upstream security fixes). **Alpine 3.16** (PHP 7.4 / 8.0 only) stays on **`1.26.1-r2`** (because official PHP images do not ship modern versions of Alpine for these legacy versions).

> [!NOTE]  
> CVEs below are in **[nginx/nginx](https://github.com/nginx/nginx)** upstream, not in this repo. This PR only bumps the NGINX we install.


> [!IMPORTANT]  
> If you are running a `7.4-fpm-nginx-alpine` or `8.0-fpm-nginx-alpine`, you will still be vulnerable because PHP no longer is providing image updates. See our [SECURITY.md](SECURITY.md) for more information why we still provide old versions.

---

## Upstream CVEs (NGINX 1.28.3)
| CVE | CVSS 3.1 | NVD | nginx | Issue | F5 advisory |
| --- | ---: | :---: | :---: | --- | --- |
| [CVE-2026-27654](https://www.cve.org/CVERecord?id=CVE-2026-27654) | [8.2](https://nvd.nist.gov/vuln/detail/CVE-2026-27654) | High | Med | `ngx_http_dav_module` buffer overflow | [K000160382](https://my.f5.com/manage/s/article/K000160382) |
| [CVE-2026-27784](https://www.cve.org/CVERecord?id=CVE-2026-27784) | [7.8](https://nvd.nist.gov/vuln/detail/CVE-2026-27784) | High | Med | `ngx_http_mp4_module` (32-bit; `mp4`) | [K000160364](https://my.f5.com/manage/s/article/K000160364) |
| [CVE-2026-32647](https://www.cve.org/CVERecord?id=CVE-2026-32647) | [7.8](https://nvd.nist.gov/vuln/detail/CVE-2026-32647) | High | Med | `ngx_http_mp4_module` crafted MP4 | [K000160366](https://my.f5.com/manage/s/article/K000160366) |
| [CVE-2026-27651](https://www.cve.org/CVERecord?id=CVE-2026-27651) | [7.5](https://nvd.nist.gov/vuln/detail/CVE-2026-27651) | High | Low | Mail auth CRAM-MD5/APOP, `Auth-Wait` | [K000160383](https://my.f5.com/manage/s/article/K000160383) |
| [CVE-2026-28755](https://www.cve.org/CVERecord?id=CVE-2026-28755) | [5.4](https://nvd.nist.gov/vuln/detail/CVE-2026-28755) | Med | Med | Stream OCSP bypass | [K000160368](https://my.f5.com/manage/s/article/K000160368) |
| [CVE-2026-28753](https://www.cve.org/CVERecord?id=CVE-2026-28753) | [3.7](https://nvd.nist.gov/vuln/detail/CVE-2026-28753) | Low | Med | `ngx_mail_smtp_module` CRLF / DNS | [K000160367](https://my.f5.com/manage/s/article/K000160367) |

Fixed in **1.28.3+** stable (**1.29.7+** mainline) per [nginx.org advisories](https://nginx.org/en/security_advisories.html).

---

## Config

- Alpine **3.20–3.23:** `nginx_version` → **`1.28.3-r1`**. **3.16:** unchanged **`1.26.1-r2`**.
- Debian: **`1.28.3-1~bullseye`**, **`~bookworm`**, **`~trixie`**.

---

## Review

- [x] CI / matrix green for NGINX variants
- [x] Spot-check `nginx -v` on one Alpine and one Debian image