### PR TITLE
Added support for Alpine 3.24

### DIFF
--- a/scripts/conf/php-versions-base-config.yml
+++ b/scripts/conf/php-versions-base-config.yml
@@ -42,36 +42,36 @@ php_versions:
           # - 8.1.34 # Pull latest from Official PHP source
       - minor: "8.2"
         base_os:
-          - name: alpine3.22
           - name: alpine3.23
+          - name: alpine3.24
           - name: bookworm
           - name: trixie
         patch_versions:
-        #   - 8.2.30 # Pull latest from Official PHP source
+        #   - 8.2.32 # Pull latest from Official PHP source
       - minor: "8.3"
         base_os:
-          - name: alpine3.22
           - name: alpine3.23
+          - name: alpine3.24
           - name: bookworm
           - name: trixie
         patch_versions:
-          # - 8.3.29 # Pull latest from Official PHP source
+          # - 8.3.32 # Pull latest from Official PHP source
       - minor: "8.4"
         base_os:
-          - name: alpine3.22
           - name: alpine3.23
+          - name: alpine3.24
           - name: bookworm
           - name: trixie
         patch_versions:
-        #   - 8.4.16 # Pull latest from Official PHP source
+        #   - 8.4.23 # Pull latest from Official PHP source
       - minor: "8.5"
         base_os:
-          - name: alpine3.22
           - name: alpine3.23
+          - name: alpine3.24
           - name: bookworm
           - name: trixie
         patch_versions:
-        #   - 8.5.1 # Pull latest from Official PHP source
+        #   - 8.5.8 # Pull latest from Official PHP source
 
 operating_systems:
   - family: alpine
@@ -108,6 +108,10 @@ operating_systems:
         version: alpine3.23
         number: 3.23
         nginx_version: 1.30.1-r1
+      - name: "Alpine 3.24"
+        version: alpine3.24
+        number: 3.24
+        nginx_version: 1.30.3-r1
   - family: debian
     default: true
     versions:

--- a/scripts/get-php-versions.sh
+++ b/scripts/get-php-versions.sh
@@ -238,7 +238,7 @@ function echo_color_message (){
 if [ "$SKIP_DOWNLOAD" = false ]; then
     echo_color_message yellow "⚡️ Getting PHP Versions from $PHP_VERSIONS_ACTIVE_JSON_FEED"
     # Fetch the JSON from the PHP website
-    php_net_version_json=$(curl -s $PHP_VERSIONS_ACTIVE_JSON_FEED)
+    php_net_version_json=$(curl -sS --fail --retry 5 --retry-all-errors --max-time 15 "$PHP_VERSIONS_ACTIVE_JSON_FEED")
 
     # Parse the fetched JSON data and optionally validate PHP versions on DockerHub
     if [ "$SKIP_DOCKERHUB_VALIDATION" = true ]; then


### PR DESCRIPTION
## What this PR does

Adds Alpine 3.24 support, following the same approach as #638 (Alpine 3.23 support):

- Added `alpine3.24` as a base OS for PHP 8.2, 8.3, 8.4, and 8.5 — all of these have official `php:*-alpine3.24` images available on Docker Hub
- Kept the two latest Alpine versions (3.23 and 3.24) on active PHP versions, consistent with what was done in #638

## Notes

- `alpine3.24` becomes the new default for the `alpine` tag suffix on supported PHP versions